### PR TITLE
[대기열 시스템 v2] Redis 기반 대기열 시스템 구현

### DIFF
--- a/buildSrc/src/main/groovy/zariyo.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/zariyo.java-conventions.gradle
@@ -16,13 +16,16 @@ repositories {
 }
 
 dependencies {
-    implementation platform('org.springframework.boot:spring-boot-dependencies:3.4.4')
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${libs.versions.boot.get()}")
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     compileOnly "org.projectlombok:lombok:${libs.versions.lombok.get()}"
     annotationProcessor "org.projectlombok:lombok:${libs.versions.lombok.get()}"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 tasks.named('test') {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-spring-boot = "3.4.4"
+boot = "3.4.4"
 lombok = "1.18.34"
 java = "17"
 
 [plugins]
-spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
+spring-boot = { id = "org.springframework.boot", version.ref = "boot" }

--- a/zariyo-queue/build.gradle
+++ b/zariyo-queue/build.gradle
@@ -2,3 +2,7 @@ plugins {
     id 'zariyo.java-conventions'
     alias(libs.plugins.spring.boot)
 }
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+}

--- a/zariyo-queue/src/main/java/com/zariyo/ZariyoQueueApplication.java
+++ b/zariyo-queue/src/main/java/com/zariyo/ZariyoQueueApplication.java
@@ -2,7 +2,9 @@ package com.zariyo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class ZariyoQueueApplication {
     public static void main(String[] args) {

--- a/zariyo-queue/src/main/java/com/zariyo/api/QueueController.java
+++ b/zariyo-queue/src/main/java/com/zariyo/api/QueueController.java
@@ -1,0 +1,54 @@
+package com.zariyo.api;
+
+import com.zariyo.api.dto.QueueDto;
+import com.zariyo.service.QueueService;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/queue")
+@RequiredArgsConstructor
+@Validated
+public class QueueController {
+
+    private final QueueService queueService;
+
+    /**
+     * 대기열 생성 여부 결정
+     * @return QueueDto - OPEN(즉시 입장) 또는 WAITING(대기열 진입)
+     */
+    @GetMapping("/token")
+    public ResponseEntity<QueueDto> enterOrEnqueue() {
+        return ResponseEntity.ok(queueService.enterOrEnqueue());
+    }
+
+    /**
+     * 토큰 유효성 검사 및 대기열 순번, 입장 가능 여부 확인 (10초 주기 폴링)
+     *
+     * @param token 발급받은 토큰 (NotBlank)
+     * @param entryNumber 대기열 진입 순번
+     * @return QueueDto - 현재 대기열 상태 정보
+     */
+    @GetMapping("/check")
+    public ResponseEntity<QueueDto> checkQueueStatus(@RequestParam @NotBlank String token, @RequestParam int entryNumber) {
+        return ResponseEntity.ok(queueService.getQueuePosition(token, entryNumber));
+    }
+
+    /**
+     * 토큰 Redis TTL 갱신 (중도 이탈자 제거용)
+     *
+     * 지속적 폴링을 통해 현재 접속 중인 유저의 TTL을 업데이트.
+     * 최대한 경량화해 부하 없는 폴링 처리를 목표
+     *
+     * @param token 갱신할 토큰 (NotBlank)
+     * @return ResponseEntity<Void> 200 OK
+     */
+    @GetMapping("/status")
+    public ResponseEntity<Void> refreshTokenTTL(@RequestParam @NotBlank String token) {
+        queueService.refreshTokenTTL(token);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/api/dto/QueueDto.java
+++ b/zariyo-queue/src/main/java/com/zariyo/api/dto/QueueDto.java
@@ -1,0 +1,33 @@
+package com.zariyo.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class QueueDto {
+    private String queueToken;
+    private int entryNumber;
+    private int position;
+    private QueueStatus status;
+
+    public static QueueDto waiting(String token, int entryNumber, int position) {
+        return QueueDto.builder()
+                .queueToken(token)
+                .entryNumber(entryNumber)
+                .position(position)
+                .status(QueueStatus.WAITING)
+                .build();
+    }
+
+    public static QueueDto open(String token) {
+        return QueueDto.builder()
+                .queueToken(token)
+                .status(QueueStatus.OPEN)
+                .build();
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/api/dto/QueueStatus.java
+++ b/zariyo-queue/src/main/java/com/zariyo/api/dto/QueueStatus.java
@@ -1,0 +1,11 @@
+package com.zariyo.api.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum QueueStatus {
+    WAITING("대기중"),
+    OPEN("입장");
+    private final String message;
+    QueueStatus(String message) { this.message = message; }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/config/LockRedisConfig.java
+++ b/zariyo-queue/src/main/java/com/zariyo/config/LockRedisConfig.java
@@ -1,0 +1,26 @@
+package com.zariyo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class LockRedisConfig {
+
+    @Value("${redis.lock.host}")
+    private String lockHost;
+
+    @Value("${redis.lock.port}")
+    private int lockPort;
+
+    @Bean(name = "lockRedisTemplate")
+    public StringRedisTemplate queueRedisTemplate() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(lockHost, lockPort);
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+        return new StringRedisTemplate(factory);
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/config/MainRedisConfig.java
+++ b/zariyo-queue/src/main/java/com/zariyo/config/MainRedisConfig.java
@@ -1,0 +1,25 @@
+package com.zariyo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class MainRedisConfig {
+    @Value("${redis.main.host}")
+    private String redisHost;
+
+    @Value("${redis.main.port}")
+    private int redisPort;
+
+    @Bean(name = "mainRedisTemplate")
+    public StringRedisTemplate mainRedisTemplate() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+        return new StringRedisTemplate(factory);
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/config/QueueRedisConfig.java
+++ b/zariyo-queue/src/main/java/com/zariyo/config/QueueRedisConfig.java
@@ -1,0 +1,27 @@
+package com.zariyo.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class QueueRedisConfig {
+
+    @Value("${redis.queue.host}")
+    private String redisHost;
+
+    @Value("${redis.queue.port}")
+    private int redisPort;
+
+    @Bean(name = "queueRedisTemplate")
+    public StringRedisTemplate queueRedisTemplate() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+        return new StringRedisTemplate(factory);
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/config/RedisMessageConfig.java
+++ b/zariyo-queue/src/main/java/com/zariyo/config/RedisMessageConfig.java
@@ -1,0 +1,26 @@
+package com.zariyo.config;
+
+import com.zariyo.infra.message.RedisExpiredEventListener;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisMessageConfig {
+
+    @Qualifier("mainRedisTemplate")
+    private final StringRedisTemplate mainRedisTemplate;
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(mainRedisTemplate.getConnectionFactory()); // 메인 레디스 팩토리 연결
+        container.addMessageListener(new RedisExpiredEventListener(mainRedisTemplate), new PatternTopic("__keyevent@*__:expired"));
+        return container;
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/exception/ErrorCode.java
+++ b/zariyo-queue/src/main/java/com/zariyo/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.zariyo.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러가 발생했습니다."),
+    ALREADY_IN_QUEUE(HttpStatus.CONFLICT, "이미 대기열에 등록된 사용자입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "대기열에 해당 토큰이 존재하지 않습니다."),
+    LUA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis Lua 스크립트 실행 중 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/exception/ErrorMessage.java
+++ b/zariyo-queue/src/main/java/com/zariyo/exception/ErrorMessage.java
@@ -1,0 +1,15 @@
+package com.zariyo.exception;
+
+public record ErrorMessage(
+        String code,
+        int status,
+        String message
+) {
+    public static ErrorMessage withErrorCode(ErrorCode errorCode) {
+        return new ErrorMessage(
+                errorCode.name(),
+                errorCode.getStatus().value(),
+                errorCode.getMessage()
+        );
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/exception/ExceptionAdvice.java
+++ b/zariyo-queue/src/main/java/com/zariyo/exception/ExceptionAdvice.java
@@ -1,0 +1,19 @@
+package com.zariyo.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(QueueException.class)
+    public ResponseEntity<ErrorMessage> handleQueueException(QueueException e) {
+        return ResponseEntity.status(e.getErrorCode().getStatus()).body(ErrorMessage.withErrorCode(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(LuaScriptException.class)
+    public ResponseEntity<ErrorMessage> handleLuaScriptException(LuaScriptException e) {
+        return ResponseEntity.status(e.getErrorCode().getStatus()).body(ErrorMessage.withErrorCode(e.getErrorCode()));
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/exception/LuaScriptException.java
+++ b/zariyo-queue/src/main/java/com/zariyo/exception/LuaScriptException.java
@@ -1,0 +1,14 @@
+package com.zariyo.exception;
+
+import lombok.Getter;
+
+@Getter
+public class LuaScriptException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public LuaScriptException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/exception/QueueException.java
+++ b/zariyo-queue/src/main/java/com/zariyo/exception/QueueException.java
@@ -1,0 +1,14 @@
+package com.zariyo.exception;
+
+import lombok.Getter;
+
+@Getter
+public class QueueException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public QueueException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/infra/QueueRedisRepository.java
+++ b/zariyo-queue/src/main/java/com/zariyo/infra/QueueRedisRepository.java
@@ -1,0 +1,190 @@
+package com.zariyo.infra;
+
+import com.zariyo.exception.ErrorCode;
+import com.zariyo.exception.LuaScriptException;
+import com.zariyo.exception.QueueException;
+import com.zariyo.infra.lua.LuaScriptManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+
+@Repository
+@RequiredArgsConstructor
+public class QueueRedisRepository {
+    @Qualifier("mainRedisTemplate")
+    private final StringRedisTemplate mainRedisTemplate;
+
+    @Qualifier("queueRedisTemplate")
+    private final StringRedisTemplate queueRedisTemplate;
+
+    @Qualifier("lockRedisTemplate")
+    private final StringRedisTemplate lockRedisTemplate;
+
+    private final LuaScriptManager luaScriptManager;
+
+    public static final String MAIN_REDIS_KEY = "main:";
+    public static final String MAIN_COUNTER_KEY = "main:current";
+    private static final String MAIN_THRESHOLD_KEY = "threshold:";
+    private static final String QUEUE_REDIS_KEY = "queue:";
+    private static final String QUEUE_PUSH_COUNT = "push:";
+    private static final String QUEUE_EXIT_COUNT = "exit:";
+
+    /**
+     * 메인 입장 최대 허용 인원 조회
+     * @return 현재 허용 인원 / 디폴트(500)
+     */
+    public int getMainThreshold() {
+        return Integer.parseInt(
+                Optional.ofNullable(mainRedisTemplate.opsForValue().get(MAIN_THRESHOLD_KEY))
+                        .orElse("500")
+        );
+    }
+
+    /**
+     * 현재 메인에 접속중인 유저 수
+     * @return 접속중인 유저수 / 디폴트(0)
+     */
+    public int getCurrentMainUserCount() {
+        return Integer.parseInt(
+                Optional.ofNullable(mainRedisTemplate.opsForValue().get(MAIN_COUNTER_KEY))
+                        .orElse("0")
+        );
+    }
+
+    /**
+     * 입장 가능 여부 체크 후 MAIN Redis에 추가
+     * (Lua로 원자성 보장)
+     * @param token 발급 받은 토큰
+     * @return true = 입장성공 / false = 대기상태
+     */
+    public boolean addToOpenSet(String token) {
+        Long result = Optional.ofNullable(
+                mainRedisTemplate.execute(
+                        luaScriptManager.getScript("addToOpenSet"),
+                        List.of(MAIN_REDIS_KEY + token, MAIN_COUNTER_KEY, MAIN_THRESHOLD_KEY),
+                        "10"
+                )
+        ).orElseThrow(() -> new LuaScriptException(ErrorCode.LUA_ERROR));
+        return result == 1L;
+    }
+
+    /**
+     * 대기열에 토큰 추가
+     * @param token 발급 받은 토큰
+     * @return 대기열에 추가된 순번
+     */
+    public int enqueue(String token) {
+        return Optional.ofNullable(
+                        queueRedisTemplate.execute(
+                                luaScriptManager.getScript("enqueue"),
+                                List.of(QUEUE_REDIS_KEY, QUEUE_PUSH_COUNT),
+                                token
+                        )
+                ).map(Long::intValue)
+                .orElseThrow(() -> new QueueException(ErrorCode.LUA_ERROR));
+    }
+
+    /**
+     * 대기열에서 입장토큰 저장 영역으로 이동
+     * @param currentOpenCount 이동할 인원 수
+     * @return 현재 남은 대기열 인원 수
+     */
+    public int moveToOpenSet(int currentOpenCount) {
+        List<String> tokens = queueRedisTemplate.opsForList().leftPop(QUEUE_REDIS_KEY, currentOpenCount);
+        if (tokens == null || tokens.isEmpty()) {
+            return 0;
+        }
+
+        List<String> keys = new ArrayList<>();
+        for (String token : tokens) {
+            keys.add(MAIN_REDIS_KEY + token);
+        }
+        keys.add(MAIN_COUNTER_KEY);
+
+        Long move = Optional.ofNullable(
+                mainRedisTemplate.execute(
+                        luaScriptManager.getScript("moveToOpenSet"),
+                        keys,
+                        "1"
+                )
+        ).orElseThrow(() -> new LuaScriptException(ErrorCode.LUA_ERROR));
+
+        queueRedisTemplate.opsForValue().increment(QUEUE_EXIT_COUNT);
+        return Optional.ofNullable(queueRedisTemplate.opsForList().size(QUEUE_REDIS_KEY)).orElse(0L).intValue();
+    }
+
+    /**
+     * 토큰 입장 상태 조회
+     * (main Redis에 토큰 존재 여부)
+     * @param token 토큰
+     * @return true = 입장 가능, false = 대기 중
+     */
+    public boolean getQueueStatus(String token) {
+        return Boolean.TRUE.equals(mainRedisTemplate.hasKey(MAIN_REDIS_KEY + token));
+    }
+
+    /**
+     * 대기열에서 나간 인원 수 조회
+     * @return 나간 인원 수
+     */
+    public int getQueueExitCount() {
+        return Integer.parseInt(
+                Optional.ofNullable(queueRedisTemplate.opsForValue().get(QUEUE_EXIT_COUNT))
+                        .orElse("0")
+        );
+    }
+
+    /**
+     * 토큰 TTL 갱신
+     * (폴링시 TTL 갱신 처리)
+     * @param token 토큰
+     */
+
+    public void refreshTokenTTL(String token) {
+        mainRedisTemplate.expire(MAIN_REDIS_KEY + token, 10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * 락 획득 시도
+     * (Lua 원자성, TTL 설정)
+     * @param key 락 키
+     * @param ttlSeconds 락 유지 시간
+     * @return true = 락 획득 성공
+     */
+    public boolean tryAcquireLock(String key, int ttlSeconds) {
+        DefaultRedisScript<Long> script = luaScriptManager.getScript("schedulerLock");
+        Long checkValue = lockRedisTemplate.execute(
+                script,
+                List.of(key),
+                "vary",
+                String.valueOf(ttlSeconds)
+        );
+        return checkValue != null && checkValue == 1L;
+    }
+
+
+    /**
+     * 락 TTL 갱신
+     * @param key 락 키
+     * @param ttlSeconds 새 TTL
+     */
+    public void refreshLock(String key, int ttlSeconds) {
+        lockRedisTemplate.expire(key, ttlSeconds, TimeUnit.SECONDS);
+    }
+
+    /**
+     * 락 해제
+     * @param key 락 키
+     */
+    public void releaseLock(String key) {
+        lockRedisTemplate.delete(key);
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/infra/lua/LuaScriptManager.java
+++ b/zariyo-queue/src/main/java/com/zariyo/infra/lua/LuaScriptManager.java
@@ -1,0 +1,51 @@
+package com.zariyo.infra.lua;
+
+import com.zariyo.exception.ErrorCode;
+import com.zariyo.exception.LuaScriptException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class LuaScriptManager {
+
+    private final Map<String, DefaultRedisScript<Long>> scripts = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        loadScript("enqueue", "lua/enqueue.lua");
+        loadScript("moveToOpenSet", "lua/moveToOpenSet.lua");
+        loadScript("addToOpenSet", "lua/addToOpenSet.lua");
+        loadScript("schedulerLock", "lua/schedulerLock.lua");
+    }
+
+    private void loadScript(String key, String path) {
+        try {
+            Resource resource = new ClassPathResource(path);
+            String lua = Files.readString(resource.getFile().toPath());
+            DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+            script.setScriptText(lua);
+            script.setResultType(Long.class);
+            scripts.put(key, script);
+        } catch (IOException e) {
+            throw new LuaScriptException(ErrorCode.LUA_ERROR);
+        }
+    }
+
+    public DefaultRedisScript<Long> getScript(String key) {
+        DefaultRedisScript<Long> script = scripts.get(key);
+        if (script == null) {
+            throw new IllegalArgumentException("스크립트 없음: " + key);
+        }
+        return script;
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/infra/message/RedisExpiredEventListener.java
+++ b/zariyo-queue/src/main/java/com/zariyo/infra/message/RedisExpiredEventListener.java
@@ -1,0 +1,23 @@
+package com.zariyo.infra.message;
+
+import com.zariyo.infra.QueueRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisExpiredEventListener implements MessageListener {
+
+    private final StringRedisTemplate mainRedisTemplate;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+        if (expiredKey.startsWith(QueueRedisRepository.MAIN_REDIS_KEY)) {
+            mainRedisTemplate.opsForValue().decrement(QueueRedisRepository.MAIN_COUNTER_KEY);
+        }
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/service/QueueService.java
+++ b/zariyo-queue/src/main/java/com/zariyo/service/QueueService.java
@@ -1,0 +1,113 @@
+package com.zariyo.service;
+
+import com.zariyo.api.dto.QueueDto;
+import com.zariyo.infra.QueueRedisRepository;
+import com.zariyo.service.event.QueueStartedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+    private final QueueRedisRepository queueRedisRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    private static final String SCHEDULER_LOCK_KEY = "scheduler-lock";
+
+    /**
+     * 메인 입장 최대 허용 인원 조회
+     * @return 허용 인원 수 (Threshold)
+     */
+    public int getMainThreshold(){
+        return queueRedisRepository.getMainThreshold();
+    }
+
+    /**
+     * 현재 메인 입장자 수 조회
+     * @return 현재 메인 입장한 유저 수
+     */
+    public int getCurrentMainUserCount() {
+        return queueRedisRepository.getCurrentMainUserCount();
+    }
+
+    /**
+     * 바로입장 or 대기열
+     */
+    public QueueDto enterOrEnqueue() {
+        String token = UUID.randomUUID().toString();
+        if(queueRedisRepository.addToOpenSet(token)){
+            return QueueDto.open(token);
+        }
+        int queueEntryNumber = queueRedisRepository.enqueue(token);
+        int position = queueEntryNumber - queueRedisRepository.getQueueExitCount();
+        return QueueDto.waiting(token, queueEntryNumber, position);
+    }
+
+    /**
+     * 현재 메인에 입장가능한 인원 수 만큼 대기열 LIST에서 토큰을 메인 SET으로 이동
+     * @param currentOpenCount 현재 입장가능한 인원
+     * @return 이동 후 남은 대기열 사이즈
+     */
+    public int popTokens(int currentOpenCount) {
+        return queueRedisRepository.moveToOpenSet(currentOpenCount);
+    }
+
+    /**
+     * 현재 내 순번 조회 및 입장 가능 여부 확인
+     * 1. 대기열 진입 순번(entryNumber) - 현재까지 입장 완료된 인원 수 = 현재 내 순번
+     * 2. 비동기 이벤트를 발행해서 스케줄러를 시도
+     *
+     * @param token 발급받은 토큰
+     * @param entryNumber 대기열 진입 순번
+     * @return 입장 가능 상태(Open) 또는 대기 상태(Waiting)
+     */
+    public QueueDto getQueuePosition(String token, int entryNumber) {
+        eventPublisher.publishEvent(new QueueStartedEvent(token));
+        if(queueRedisRepository.getQueueStatus(token)){
+            return QueueDto.open(token);
+        } else {
+            int position = entryNumber - queueRedisRepository.getQueueExitCount();
+            return QueueDto.waiting(token, entryNumber,position);
+        }
+    }
+
+    /**
+     * 현재 접속중인 유저 토큰 TTL 갱신
+     * 지속적인 폴링을 통해 중도 이탈자 제거를 목표
+     * @param token 갱신할 토큰
+     */
+    public void refreshTokenTTL(String token) {
+        queueRedisRepository.refreshTokenTTL(token);
+    }
+
+    /**
+     * 스케줄러 락 획득 시도
+     * 락을 획득하면 스케줄러를 실행할 수 있음.
+     *
+     * @return 락 획득 성공 여부
+     */
+    public boolean checkSchedulerLock() {
+        return queueRedisRepository.tryAcquireLock(SCHEDULER_LOCK_KEY, 10);
+    }
+
+    /**
+     * 스케줄러 락 TTL 갱신
+     * 스케줄러 실행 중 서버 다운을 고려해 TTL을 삽입하고
+     * 스케줄러 주기마다 TTL을 연장해 서버 장애 대비.
+     */
+    public void refreshSchedulerLock() {
+        queueRedisRepository.refreshLock(SCHEDULER_LOCK_KEY, 10);
+    }
+
+    /**
+     * 스케줄러 락 해제
+     * 스케줄러 종료 시 락 삭제 처리.
+     */
+    public void releaseSchedulerLock() {
+        queueRedisRepository.releaseLock(SCHEDULER_LOCK_KEY);
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/service/event/QueueEventListener.java
+++ b/zariyo-queue/src/main/java/com/zariyo/service/event/QueueEventListener.java
@@ -1,0 +1,48 @@
+package com.zariyo.service.event;
+
+import com.zariyo.exception.LuaScriptException;
+import com.zariyo.service.QueueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueEventListener {
+
+    private final QueueService queueService;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    @Async
+    @EventListener
+    public void handleQueueStarted(QueueStartedEvent event) {
+        if (queueService.checkSchedulerLock()) {
+            try {
+                log.info("락 획득 성공: 큐 처리 시작");
+                scheduler.scheduleAtFixedRate(() -> {
+                    queueService.refreshSchedulerLock();
+                    int openCount = queueService.getMainThreshold() - queueService.getCurrentMainUserCount();
+                    if (openCount > 0) {
+                        int currentQueueSize = queueService.popTokens(openCount);
+                        log.info("현재 오픈 수 openCount={}, 큐 크기 currentQueueSize={}", openCount, currentQueueSize);
+                        if (currentQueueSize == 0) {
+                            log.info("대기열 모두 입장 완료. 스케줄러 종료");
+                            queueService.releaseSchedulerLock();
+                            scheduler.shutdownNow();
+                        }
+                    }
+                }, 0, 2, TimeUnit.SECONDS);
+            }  catch (LuaScriptException e) {
+                log.error("LuaScript 에러: {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/zariyo-queue/src/main/java/com/zariyo/service/event/QueueStartedEvent.java
+++ b/zariyo-queue/src/main/java/com/zariyo/service/event/QueueStartedEvent.java
@@ -1,0 +1,9 @@
+package com.zariyo.service.event;
+
+import org.springframework.context.ApplicationEvent;
+
+public class QueueStartedEvent extends ApplicationEvent {
+    public QueueStartedEvent(Object source) {
+        super(source);
+    }
+}

--- a/zariyo-queue/src/main/resources/application.yml
+++ b/zariyo-queue/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+redis:
+  main:
+    host: localhost
+    port: 6379
+  queue:
+    host: localhost
+    port: 6380
+  lock:
+    host: localhost
+    port: 6381

--- a/zariyo-queue/src/main/resources/lua/addToOpenSet.lua
+++ b/zariyo-queue/src/main/resources/lua/addToOpenSet.lua
@@ -1,0 +1,10 @@
+local threshold = tonumber(redis.call('GET', KEYS[3]) or '500')
+local currentCount = tonumber(redis.call('GET', KEYS[2]) or '0')
+
+if currentCount < threshold then
+    redis.call('SET', KEYS[1], '1', 'EX', ARGV[1])
+    redis.call('INCRBY', KEYS[2], 1)
+    return 1
+else
+    return 0
+end

--- a/zariyo-queue/src/main/resources/lua/enqueue.lua
+++ b/zariyo-queue/src/main/resources/lua/enqueue.lua
@@ -1,0 +1,2 @@
+redis.call('RPUSH', KEYS[1], ARGV[1])
+return redis.call('INCRBY', KEYS[2], 1)

--- a/zariyo-queue/src/main/resources/lua/moveToOpenSet.lua
+++ b/zariyo-queue/src/main/resources/lua/moveToOpenSet.lua
@@ -1,0 +1,7 @@
+for i = 1, #KEYS - 1 do
+  redis.call('SET', KEYS[i], '1', 'EX', 10)
+end
+
+redis.call('INCRBY', KEYS[#KEYS], ARGV[1])
+
+return 1

--- a/zariyo-queue/src/main/resources/lua/schedulerLock.lua
+++ b/zariyo-queue/src/main/resources/lua/schedulerLock.lua
@@ -1,0 +1,6 @@
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+    return 1
+else
+    return 0
+end

--- a/zariyo-queue/src/test/java/com/zariyo/QueueIntegrationTest.java
+++ b/zariyo-queue/src/test/java/com/zariyo/QueueIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.zariyo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zariyo.api.dto.QueueDto;
+import com.zariyo.api.dto.QueueStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("Queue 통합 테스트")
+class QueueIntegrationTest extends TestContainerConfig {
+
+    @Autowired MockMvc mvc;
+    @Autowired ObjectMapper om;
+    @Autowired
+    StringRedisTemplate mainRedisTemplate;
+
+    private static final int TOTAL_USERS = 1000;
+    private static final int MAX_CAPACITY = 500;
+
+    @Test
+    @DisplayName("대기열 전체 흐름 테스트")
+    void fullQueueFlow() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(100);
+        List<Future<QueueDto>> futures = new ArrayList<>();
+
+        // 1. [Step1] 사용자 1000명 동시에 입장 시도
+        for (int i = 0; i < TOTAL_USERS; i++) {
+            futures.add(executor.submit(() -> {
+                String response = mvc.perform(get("/queue/token"))
+                        .andReturn().getResponse().getContentAsString();
+                return om.readValue(response, QueueDto.class);
+            }));
+        }
+        executor.shutdown();
+        executor.awaitTermination(30, TimeUnit.SECONDS);
+
+        List<QueueDto> openUsers = new ArrayList<>();
+        List<QueueDto> waitingUsers = new ArrayList<>();
+        for (Future<QueueDto> f : futures) {
+            QueueDto user = f.get();
+            if (user.getStatus() == QueueStatus.OPEN) {
+                openUsers.add(user);
+            } else {
+                waitingUsers.add(user);
+            }
+        }
+
+        assertThat(openUsers).hasSize(MAX_CAPACITY);
+        assertThat(waitingUsers).hasSize(TOTAL_USERS - MAX_CAPACITY);
+
+        // 2. [Step2] 대기열 사용자들 폴링 시작 (입장 가능할 때까지 대기)
+        ExecutorService pollingExecutor = Executors.newFixedThreadPool(60);
+        List<Callable<Void>> pollingTasks = new ArrayList<>();
+
+        waitingUsers.forEach(user -> pollingTasks.add(() -> {
+            await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+                String pollResponse = mvc.perform(get("/queue/check")
+                                .param("token", user.getQueueToken())
+                                .param("entryNumber", String.valueOf(user.getEntryNumber())))
+                        .andReturn().getResponse().getContentAsString();
+
+                QueueDto pollResult = om.readValue(pollResponse, QueueDto.class);
+                assertThat(pollResult.getStatus()).isEqualTo(QueueStatus.OPEN);
+            });
+            return null;
+        }));
+
+        pollingExecutor.invokeAll(pollingTasks);
+
+        // 3. [Step3] TTL 만료 후 main:current 감소 확인
+        Thread.sleep(11_000); // 10초 TTL + 1초 버퍼
+
+        String currentCountStr = mainRedisTemplate.opsForValue().get("main:current");
+        int currentCount = currentCountStr == null ? 0 : Integer.parseInt(currentCountStr);
+
+        assertThat(currentCount).isLessThanOrEqualTo(MAX_CAPACITY);
+
+        // 4. [Step4] 스케줄러 락이 적절히 회수됐는지 확인 (선택적)
+        Boolean lockExists = mainRedisTemplate.hasKey("scheduler-lock");
+        assertThat(lockExists).isFalse();
+    }
+}

--- a/zariyo-queue/src/test/java/com/zariyo/TestContainerConfig.java
+++ b/zariyo-queue/src/test/java/com/zariyo/TestContainerConfig.java
@@ -1,0 +1,31 @@
+package com.zariyo;
+
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+public abstract class TestContainerConfig {
+
+    @Container
+    protected static GenericContainer<?> redis = new GenericContainer<>("redis:7.0")
+            .withExposedPorts(6379)
+            .withCommand("redis-server --notify-keyspace-events Ex")
+            .waitingFor(Wait.forListeningPort());
+
+    @DynamicPropertySource
+    static void configureRedis(DynamicPropertyRegistry registry) {
+        registry.add("redis.main.host", redis::getHost);
+        registry.add("redis.main.port", () -> redis.getMappedPort(6379));
+        registry.add("redis.queue.host", redis::getHost);
+        registry.add("redis.queue.port", () -> redis.getMappedPort(6379));
+        registry.add("redis.lock.host", redis::getHost);
+        registry.add("redis.lock.port", () -> redis.getMappedPort(6379));
+    }
+}


### PR DESCRIPTION
## 고려사항

### 1. 스케일 아웃을 위한 동적 Threshold 관리  
- 메인 입장 허용 수(Threshold)는 Redis에 저장해 운영 중에도 유연하게 변경 가능하도록 설계

### 2. 접속자 수 초과 방지: 원자적 Lua Script 적용  
- 단순히 `get current → get threshold → 비교 후 → set` 연산으로 분리할 경우, 경쟁 조건 발생  
  예: A와 B가 동시에 입장 시도 → A가 count 조회 후 입장 처리 중에 B가 먼저 입장  
- 방지 방법: Redis Lua Script로 `SET + INCRBY + 조건 비교`를 하나의 요청으로 처리하여 원자성 보장

### 3. Redis 장점 활용  
- Redis의 인메모리 기반 특성을 최대한 활용  
- 모든 연산을 O(1)로 구성해 빠른 처리 성능 보장

### 4. 접속 종료 시점 추적: TTL + Redis Keyspace Notification  
- 유저가 브라우저 종료 또는 페이지 이탈 시 접속 인원 수 감소 감지가 어려움  
- 해결책: 토큰 등록 시 EXPIRE 설정(10초), Redis Keyspace Notification으로 TTL 만료 이벤트 감지해 `main:current` 감소 처리

---

## `GET /queue/token`
### 사용자가 페이지 접속 시 토큰 발급 시도

#### Redis에서 현재 접속자 수(current)가 허용 수(threshold)보다 작으면:
→ OPEN 상태 반환
→ 토큰 Redis에 저장 (main:{token}) 및 TTL 10초 설정
→ 현재 접속 인원 수 증가
#### 그렇지 않으면:
→ 대기열에 토큰 추가
→ WAITING 상태로 진입
→ 대기열 진입 순번 및 토큰 반환

## `GET /queue/check`
### 클라이언트는 10초 주기로 폴링
- 현재 입장 가능 여부 확인 (main:{token} 키 존재 여부)
- 대기열 진입 순번 - 나간 인원 수 = 현재 위치 계산
- 만약 토큰이 mainRedis에 존재하면 → OPEN 반환
- 그렇지 않으면 계속 대기(WAITING)

## `@EventListener(QueueStartedEvent)`
### 폴링 중인 스레드 하나가 QueueStartedEvent를 비동기로 발행
- 스케줄러 락 획득 (Lua 기반 O(1) 연산)
- 락 획득 시 → 2초 간격으로 입장 처리 시작:
- openCount = threshold - current
- 대기열에서 openCount만큼 꺼내 mainRedis에 토큰 저장 + TTL 10초 설정
- 동시에 main:current 증가
- 대기열 소진 시 락 해제 및 스케줄러 종료

## `GET /queue/status`
### 메인에 입장한 유저는 주기적으로 TTL 연장
- 토큰 TTL 만료 시 → Redis EXPIRE 이벤트 리스너가 main:current 감소 처리

