### PR TITLE
[콘서트 예약 시스템] Swagger 기반 API 문서화

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ java = "17"
 redisson = "3.46.0"
 jwt = "0.11.5"
 jacoco = "0.8.11"
+swagger = "2.8.8"
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "boot" }

--- a/zariyo-main/build.gradle
+++ b/zariyo-main/build.gradle
@@ -12,5 +12,7 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${libs.versions.jwt.get()}"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:${libs.versions.jwt.get()}"
 
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${libs.versions.swagger.get()}"
+
     testImplementation 'org.testcontainers:mysql'
 }

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/ConcertController.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/ConcertController.java
@@ -1,0 +1,228 @@
+package com.zariyo.concert.api;
+
+import com.zariyo.concert.api.response.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/concerts")
+@RequiredArgsConstructor
+public class ConcertController {
+
+    @Operation(
+            summary = "콘서트 상세 정보 조회",
+            description = "콘서트 정보(콘서트명, 장소, 콘서트 회차 및 일자, 좌석 등급별 가격, 공연 설명) 조회 API",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "콘서트 정보 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                            {
+                                              "concert": {
+                                                    "concertId": 1,
+                                                    "concertName": "zariyo 콘서트",
+                                                    "address": "서울특별시 송파구 올림픽로 424"
+                                               },
+                                              "schedules": [
+                                                {
+                                                  "scheduleId": 1,
+                                                  "concertDate": "2025-05-01 09:00"
+                                                },
+                                                {
+                                                  "scheduleId": 2,
+                                                  "concertDate": "2025-05-01 14:00"
+                                                }
+                                              ],
+                                              "gradePrices": [
+                                                {
+                                                  "grade": "VIP",
+                                                  "price": 200000
+                                                },
+                                                {
+                                                  "grade": "R",
+                                                  "price": 150000
+                                                },
+                                                {
+                                                  "grade": "S",
+                                                  "price": 100000
+                                                }
+                                              ],
+                                              "files": [
+                                                {
+                                                  "fileId": 1,
+                                                  "fileName": "concert.jpg",
+                                                  "filePath": "/concerts/1/concert.jpg",
+                                                    "fileType": "POSTER"
+                                                },
+                                                {
+                                                  "fileId": 2,
+                                                  "fileName": "poster.jpg",
+                                                  "filePath": "/concerts/1/poster.jpg",
+                                                  "fileType": "DESCRIPTION"
+                                                }
+                                              ]
+                                            }
+                                            """
+                                    )
+                            )
+                    )
+            }
+    )
+    @GetMapping("/{concertId}")
+    public ResponseEntity<ConcertInfoResponse> getConcertInfo(@PathVariable("concertId") long concertId) {
+        // TODO: 콘서트 정보 조회 로직 구현 (콘서트명, 장소, { 콘서트날짜, 회차 }, 좌석 등급별 가격, 공연설명)
+        return ResponseEntity.ok(ConcertInfoResponse.builder().
+        concert(Concert.builder().concertId(1).concertName("zariyo 콘서트").address("서울특별시 송파구 올림픽로 424").build())
+                .schedules(List.of(
+                        Schedule.builder().scheduleId(1).concertDate(LocalDateTime.of(2025, 5, 1, 9, 0)).build(),
+                        Schedule.builder().scheduleId(2).concertDate(LocalDateTime.of(2025, 5, 1, 14, 0)).build()
+                ))
+                .gradePrices(List.of(
+                        GradePrice.builder().grade("VIP").price(BigDecimal.valueOf(200000)).build(),
+                        GradePrice.builder().grade("R").price(BigDecimal.valueOf(150000)).build(),
+                        GradePrice.builder().grade("S").price(BigDecimal.valueOf(100000)).build()
+                ))
+                .files(List.of(
+                        ConcertFile.builder().fileId(1).fileName("concert.jpg").filePath("/concerts/1/concert.jpg").fileType("POSTER").build(),
+                        ConcertFile.builder().fileId(2).fileName("poster.jpg").filePath("/concerts/1/poster.jpg").fileType("DESCRIPTION").build()
+                ))
+                .build());
+    }
+
+    @Operation(
+            summary = "콘서트 좌석 예약",
+            description = "콘서트 좌석 예약 API, 좌석 예약 성공 시 좌석 및 콘서트 정보 반환, 실패 시 에러 메시지 반환",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "콘서트 좌석 예약 성공 - 결제페이지 이동",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                            {
+                                                "reservationId": 1,
+                                                "concert":
+                                                {
+                                                    "concertId": 1,
+                                                    "concertName": "zariyo 콘서트",
+                                                    "address": "서울특별시 송파구 올림픽로 424"
+                                                },
+                                                "schedule":
+                                                {
+                                                  "scheduleId": 1,
+                                                  "concertDate": "2025-05-01 09:00"
+                                                },
+                                                "seats": [
+                                                    {
+                                                        "scheduleSeatId": 1,
+                                                        "block": "A",
+                                                        "seatNumber": "2",
+                                                        "grade": "VIP",
+                                                        "price": 200000
+                                                    },
+                                                    {
+                                                        "scheduleSeatId": 2,
+                                                        "block": "A",
+                                                        "seatNumber": "2",
+                                                        "grade": "VIP",
+                                                        "price": 200000
+                                                    }
+                                                ]
+                                            }
+                                            """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "예약 실패 - 이미 예약된 좌석",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                            {
+                                              "message": "이미 예약된 좌석이 포함되어 있습니다."
+                                            }
+                                            """
+                                    )
+                            )
+                    )
+            }
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "예약할 좌석 ID 목록",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = "[1, 2]")
+            )
+    )
+    @PostMapping("/reserve")
+    public ResponseEntity<ReservationResponse> reserveConcertSeats(@RequestBody List<Long> scheduleSeatIds) {
+        // TODO: 콘서트 좌석 예약 로직 구현 (결제창 호출, 예약 성공 시 예약 정보 반환)
+
+        return ResponseEntity.ok(ReservationResponse.builder()
+                .reservationId(1)
+                .concert(Concert.builder().concertId(1).concertName("zariyo 콘서트").address("서울특별시 송파구 올림픽로 424").build())
+                .schedule(Schedule.builder().scheduleId(1).concertDate(LocalDateTime.of(2025, 5, 1, 9, 0)).build())
+                .seats(List.of(
+                        Seat.builder().scheduleSeatId(1).block("A").seatNumber("2").grade("VIP").price(BigDecimal.valueOf(200000)).build(),
+                        Seat.builder().scheduleSeatId(2).block("A").seatNumber("2").grade("VIP").price(BigDecimal.valueOf(200000)).build()
+                ))
+                .build());
+    }
+
+
+    @Operation(
+            summary = "콘서트 좌석 조회",
+            description = "콘서트 예약시 좌석리스트 조회 API (회차 좌석 ID, 좌석구역, 좌석번호, 좌석등급, 가격)",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "좌석 리스트 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                            [
+                                              {
+                                                "scheduleSeatId": 1,
+                                                "block": "A",
+                                                "seatNumber": "1",
+                                                "grade": "VIP",
+                                                "price": 200000
+                                              },
+                                              {
+                                                "scheduleSeatId": 2,
+                                                "block": "A",
+                                                "seatNumber": "2",
+                                                "grade": "VIP",
+                                                "price": 200000
+                                              },
+                                              {
+                                                "scheduleSeatId": 3,
+                                                "block": "A",
+                                                "seatNumber": "3",
+                                                "grade": "VIP",
+                                                "price": 200000
+                                              }
+                                            ]
+                                            """
+                                    )
+                            )
+                    )
+            }
+    )
+    @GetMapping("/{concertId}/seats")
+    public ResponseEntity<List<Seat>> getConcertSeats(@PathVariable("concertId") long concertId) {
+        // TODO: 콘서트 예약시 좌석리스트 조회 로직 구현 (회차 좌석 ID, 좌석구역, 좌석번호, 좌석등급, 가격)
+
+        return ResponseEntity.ok(List.of(
+                Seat.builder().scheduleSeatId(1).block("A").seatNumber("1").grade("VIP").price(BigDecimal.valueOf(200000)).build(),
+                Seat.builder().scheduleSeatId(2).block("A").seatNumber("2").grade("VIP").price(BigDecimal.valueOf(200000)).build(),
+                Seat.builder().scheduleSeatId(3).block("A").seatNumber("3").grade("VIP").price(BigDecimal.valueOf(200000)).build()
+        ));
+    }
+
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/Concert.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/Concert.java
@@ -1,0 +1,12 @@
+package com.zariyo.concert.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Concert {
+    private long concertId;
+    private String concertName;
+    private String address;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/ConcertFile.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/ConcertFile.java
@@ -1,0 +1,13 @@
+package com.zariyo.concert.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ConcertFile {
+    private long fileId;
+    private String fileName;
+    private String filePath;
+    private String fileType;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/ConcertInfoResponse.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/ConcertInfoResponse.java
@@ -1,0 +1,16 @@
+package com.zariyo.concert.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ConcertInfoResponse {
+    private Concert concert;
+    private String address;
+    private List<Schedule> schedules;
+    private List<GradePrice> gradePrices;
+    private List<ConcertFile> files;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/GradePrice.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/GradePrice.java
@@ -1,0 +1,13 @@
+package com.zariyo.concert.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class GradePrice {
+    private String grade;
+    private BigDecimal price;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/ReservationResponse.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/ReservationResponse.java
@@ -1,0 +1,15 @@
+package com.zariyo.concert.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ReservationResponse {
+    private long reservationId;
+    private Concert concert;
+    private Schedule schedule;
+    private List<Seat> seats;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/Schedule.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/Schedule.java
@@ -1,0 +1,13 @@
+package com.zariyo.concert.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class Schedule {
+    private long scheduleId;
+    private LocalDateTime concertDate;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/Seat.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/Seat.java
@@ -1,0 +1,16 @@
+package com.zariyo.concert.api.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class Seat {
+    private long scheduleSeatId;
+    private String block;
+    private String seatNumber;
+    private String grade;
+    private BigDecimal price;
+}

--- a/zariyo-main/src/main/java/com/zariyo/user/security/QueueTokenValidationFilter.java
+++ b/zariyo-main/src/main/java/com/zariyo/user/security/QueueTokenValidationFilter.java
@@ -26,6 +26,12 @@ public class QueueTokenValidationFilter extends OncePerRequestFilter {
 
         String queueToken = request.getHeader("X-QUEUE-TOKEN");
 
+        String uri = request.getRequestURI();
+        if (uri.startsWith("/swagger-ui") || uri.startsWith("/v3/api-docs")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         // Queue 토큰이 없는 경우
         if (queueToken == null || queueToken.isBlank()) {
             sendQueueTokenError(response, "QUEUE_TOKEN_REQUIRED", "대기열 토큰이 필요합니다.");

--- a/zariyo-main/src/main/java/com/zariyo/user/security/SecurityConfig.java
+++ b/zariyo-main/src/main/java/com/zariyo/user/security/SecurityConfig.java
@@ -37,8 +37,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**"
                         ).permitAll()
                         .requestMatchers(
-                                "**/reserve",
-                                "/concerts/**/seats"
+                                "/concerts/reserve",
+                                "/concerts/*/seats"
                         ).authenticated()
                         .anyRequest().permitAll()
                 )

--- a/zariyo-main/src/main/java/com/zariyo/user/security/SecurityConfig.java
+++ b/zariyo-main/src/main/java/com/zariyo/user/security/SecurityConfig.java
@@ -33,7 +33,12 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/reserve/**"
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .requestMatchers(
+                                "/reservation/**",
+                                "/concerts/**/seats"
                         ).authenticated()
                         .anyRequest().permitAll()
                 )

--- a/zariyo-main/src/main/java/com/zariyo/user/security/SecurityConfig.java
+++ b/zariyo-main/src/main/java/com/zariyo/user/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                                 "/v3/api-docs/**"
                         ).permitAll()
                         .requestMatchers(
-                                "/reservation/**",
+                                "**/reserve",
                                 "/concerts/**/seats"
                         ).authenticated()
                         .anyRequest().permitAll()


### PR DESCRIPTION
## 주요 변경 사항

- `ConcertController`의 전체 API에 Swagger 문서화 어노테이션(`@Operation`, `@ApiResponse`, `@ExampleObject`) 적용
- `/concerts/reserve`, `/concerts/{concertId}`, `/concerts/{concertId}/seats` 각각에 대한 **요청 및 응답 예시 JSON 추가**
- 좌석 예약 성공/실패에 대한 예외 응답 명시
- Swagger UI에서 각 API에 대한 설명 및 예시 확인 가능

## 테스트
> swagger - `http://localhost:8080/swagger-ui/index.html` 실행 결과 정상 적으로 출력 되는 것 확인
<img width="1167" alt="swagger" src="https://github.com/user-attachments/assets/6b39c6b8-7b68-4944-af1f-04a3f78648a6" />

