### PR TITLE
[콘서트 예약 시스템] ConcertController에 CompletableFuture 적용

### DIFF
--- a/zariyo-main/src/main/java/com/zariyo/ZariyoMainApplication.java
+++ b/zariyo-main/src/main/java/com/zariyo/ZariyoMainApplication.java
@@ -2,12 +2,10 @@ package com.zariyo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableAsync
 public class ZariyoMainApplication {
     public static void main(String[] args) {
         SpringApplication.run(ZariyoMainApplication.class, args);

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/ConcertController.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/ConcertController.java
@@ -38,8 +38,7 @@ public class ConcertController {
 
     @GetMapping("/schedules/{scheduleId}/seats")
     public CompletableFuture<ResponseEntity<AvailableSeatsResponse>> getAvailableSeats(@PathVariable Long scheduleId) {
-        return CompletableFuture.supplyAsync(() ->
-                concertFacade.getAvailableSeatsAsync(scheduleId)
-        ).thenCompose(future -> future).thenApply(ResponseEntity::ok);
+        return concertFacade.getAvailableSeatsAsync(scheduleId)
+                .thenApply(ResponseEntity::ok);
     }
 }

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/ConcertController.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/ConcertController.java
@@ -10,6 +10,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.concurrent.CompletableFuture;
+
 @RestController
 @RequestMapping("/api/concerts")
 @RequiredArgsConstructor
@@ -18,20 +20,26 @@ public class ConcertController {
     private final ConcertFacade concertFacade;
 
     @GetMapping
-    public ResponseEntity<ConcertListResponse> getConcerts(
+    public CompletableFuture<ResponseEntity<ConcertListResponse>> getConcerts(
             @PageableDefault(size = 10) Pageable pageable,
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false, defaultValue = "upcoming") String sort) {
-        return ResponseEntity.ok(concertFacade.getConcerts(pageable, sort, categoryId));
+        return CompletableFuture.supplyAsync(() ->
+                concertFacade.getConcerts(pageable, sort, categoryId)
+        ).thenApply(ResponseEntity::ok);
     }
 
     @GetMapping("/{concertId}")
-    public ResponseEntity<ConcertDetailResponse> getConcertDetail(@PathVariable Long concertId) {
-        return ResponseEntity.ok(concertFacade.getConcertDetail(concertId));
+    public CompletableFuture<ResponseEntity<ConcertDetailResponse>> getConcertDetail(@PathVariable Long concertId) {
+        return CompletableFuture.supplyAsync(() ->
+                concertFacade.getConcertDetail(concertId)
+        ).thenApply(ResponseEntity::ok);
     }
 
     @GetMapping("/schedules/{scheduleId}/seats")
-    public ResponseEntity<AvailableSeatsResponse> getAvailableSeats(@PathVariable Long scheduleId) {
-        return ResponseEntity.ok(concertFacade.getAvailableSeats(scheduleId));
+    public CompletableFuture<ResponseEntity<AvailableSeatsResponse>> getAvailableSeats(@PathVariable Long scheduleId) {
+        return CompletableFuture.supplyAsync(() ->
+                concertFacade.getAvailableSeatsAsync(scheduleId)
+        ).thenCompose(future -> future).thenApply(ResponseEntity::ok);
     }
 }

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/cache/ConcertCacheScheduler.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/cache/ConcertCacheScheduler.java
@@ -6,8 +6,6 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -16,13 +14,8 @@ public class ConcertCacheScheduler {
     @Scheduled(cron = "0 0 0 * * *")
     public void refreshConcertCaches() {
         try {
-            CompletableFuture<Void> localCacheTask =
-                    CompletableFuture.runAsync(this::evictConcertLocalCaches);
-
-            CompletableFuture<Void> redisCacheTask =
-                    CompletableFuture.runAsync(this::evictConcertRedisCaches);
-
-            CompletableFuture.allOf(localCacheTask, redisCacheTask).join();
+            evictConcertLocalCaches();
+            evictConcertRedisCaches();
         } catch (Exception e) {
             log.error("스케줄러 실패: ", e);
         }

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/facade/ConcertFacade.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/facade/ConcertFacade.java
@@ -35,16 +35,13 @@ public class ConcertFacade {
         return ConcertDetailResponse.from(concertQueryService.getConcertDetail(concertId));
     }
 
-    public AvailableSeatsResponse getAvailableSeats(Long scheduleId) {
+    public CompletableFuture<AvailableSeatsResponse> getAvailableSeatsAsync(Long scheduleId) {
         CompletableFuture<AvailableSeatsDto> availableSeatsTask =
-            CompletableFuture.supplyAsync(() -> scheduleSeatService.getAvailableSeats(scheduleId));
-        
-        CompletableFuture<List<SeatInfoDto>> allSeatsTask = 
-            CompletableFuture.supplyAsync(() -> scheduleSeatService.getAllSeats(scheduleId));
+                CompletableFuture.supplyAsync(() -> scheduleSeatService.getAvailableSeats(scheduleId));
 
-        AvailableSeatsDto availableSeatsDto = availableSeatsTask.join();
-        List<SeatInfoDto> allSeats = allSeatsTask.join();
+        CompletableFuture<List<SeatInfoDto>> allSeatsTask =
+                CompletableFuture.supplyAsync(() -> scheduleSeatService.getAllSeats(scheduleId));
 
-        return AvailableSeatsResponse.from(availableSeatsDto, allSeats);
+        return availableSeatsTask.thenCombine(allSeatsTask, AvailableSeatsResponse::from);
     }
 }

--- a/zariyo-main/src/test/java/com/zariyo/concert/api/ConcertControllerIntegrationTest.java
+++ b/zariyo-main/src/test/java/com/zariyo/concert/api/ConcertControllerIntegrationTest.java
@@ -1,258 +1,334 @@
 package com.zariyo.concert.api;
 
+import com.zariyo.concert.api.response.AvailableSeatsResponse;
+import com.zariyo.concert.api.response.ConcertDetailResponse;
+import com.zariyo.concert.api.response.ConcertListResponse;
 import com.zariyo.config.TestContainerConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.*;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+import java.math.BigDecimal;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
 class ConcertControllerIntegrationTest extends TestContainerConfig {
 
     @Autowired
-    private MockMvc mockMvc;
+    private TestRestTemplate restTemplate;
 
     @Autowired
     private StringRedisTemplate mainRedisTemplate;
 
     private static final String QUEUE_TOKEN = "queue-token";
+    private HttpHeaders headers;
 
     @BeforeEach
     void setUp() {
         mainRedisTemplate.opsForValue().set("main:" + QUEUE_TOKEN, String.valueOf(System.currentTimeMillis()));
+        headers = new HttpHeaders();
+        headers.set("X-QUEUE-TOKEN", QUEUE_TOKEN);
     }
 
     @Test
     @DisplayName("공연 목록 조회 API 통합 테스트 - 전체 공연")
-    void getConcerts_All_API_Integration() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/concerts")
-                        .param("page", "0")
-                        .param("size", "10")
-                        .param("sort", "upcoming")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concerts").isArray())
-                .andExpect(jsonPath("$.concerts").isNotEmpty())
-                .andExpect(jsonPath("$.concerts[0].title").exists())
-                .andExpect(jsonPath("$.concerts[0].categoryName").value("콘서트"))
-                .andExpect(jsonPath("$.concerts[0].hallName").exists())
-                .andExpect(jsonPath("$.concerts[0].posterUrl").exists())
-                .andExpect(jsonPath("$.currentPage").value(0))
-                .andExpect(jsonPath("$.pageSize").value(10))
-                .andExpect(jsonPath("$.totalElements").value(3));
+    void getConcerts_All_API_Integration() {
+        // when
+        ResponseEntity<ConcertListResponse> response = restTemplate.exchange(
+                "/api/concerts?page=0&size=10&sort=upcoming",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertListResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getConcerts()).isNotEmpty();
+        assertThat(response.getBody().getConcerts().get(0).getTitle()).isNotNull();
+        assertThat(response.getBody().getConcerts().get(0).getCategoryName()).isEqualTo("콘서트");
+        assertThat(response.getBody().getCurrentPage()).isEqualTo(0);
+        assertThat(response.getBody().getPageSize()).isEqualTo(10);
+        assertThat(response.getBody().getTotalElements()).isEqualTo(3);
     }
 
     @Test
     @DisplayName("공연 목록 조회 API 통합 테스트 - 카테고리별")
-    void getConcerts_ByCategory_API_Integration() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/concerts")
-                        .param("page", "0")
-                        .param("size", "10")
-                        .param("sort", "upcoming")
-                        .param("categoryId", "1")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concerts").isArray())
-                .andExpect(jsonPath("$.concerts").isNotEmpty())
-                .andExpect(jsonPath("$.concerts[0].categoryName").value("콘서트"))
-                .andExpect(jsonPath("$.totalElements").value(3));
+    void getConcerts_ByCategory_API_Integration() {
+        // when
+        ResponseEntity<ConcertListResponse> response = restTemplate.exchange(
+                "/api/concerts?page=0&size=10&sort=upcoming&categoryId=1",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertListResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getConcerts()).isNotEmpty();
+        assertThat(response.getBody().getConcerts().get(0).getCategoryName()).isEqualTo("콘서트");
+        assertThat(response.getBody().getTotalElements()).isEqualTo(3);
     }
 
     @Test
     @DisplayName("공연 목록 조회 API 통합 테스트 - sort 파라미터 없을 때 기본값(UPCOMING) 적용")
-    void getConcerts_DefaultSort_API_Integration() throws Exception {
-        // when & then - sort 파라미터를 지정하지 않으면 기본적으로 upcoming 정렬 적용
-        mockMvc.perform(get("/api/concerts")
-                        .param("page", "0")
-                        .param("size", "10")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concerts").isArray())
-                .andExpect(jsonPath("$.concerts").isNotEmpty())
-                .andExpect(jsonPath("$.totalElements").value(3))
-                // 기본 upcoming 정렬 검증: BTS(5일 후) > 아이유(10일 후) > BLACKPINK(15일 후)
-                .andExpect(jsonPath("$.concerts[0].title").value("BTS 월드투어 [Yet To Come]"))
-                .andExpect(jsonPath("$.concerts[1].title").value("아이유 콘서트 [The Golden Hour]"))
-                .andExpect(jsonPath("$.concerts[2].title").value("BLACKPINK 월드투어 [Born Pink]"));
+    void getConcerts_DefaultSort_API_Integration() {
+        // when
+        ResponseEntity<ConcertListResponse> response = restTemplate.exchange(
+                "/api/concerts?page=0&size=10",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertListResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getConcerts()).isNotEmpty();
+        assertThat(response.getBody().getTotalElements()).isEqualTo(3);
+        // 기본 upcoming 정렬 검증: BTS(5일 후) > 아이유(10일 후) > BLACKPINK(15일 후)
+        assertThat(response.getBody().getConcerts().get(0).getTitle()).isEqualTo("BTS 월드투어 [Yet To Come]");
+        assertThat(response.getBody().getConcerts().get(1).getTitle()).isEqualTo("아이유 콘서트 [The Golden Hour]");
+        assertThat(response.getBody().getConcerts().get(2).getTitle()).isEqualTo("BLACKPINK 월드투어 [Born Pink]");
     }
 
     @Test
     @DisplayName("공연 목록 조회 API 통합 테스트 - 인기순 정렬")
-    void getConcerts_PopularSort_API_Integration() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/concerts")
-                        .param("page", "0")
-                        .param("size", "10")
-                        .param("sort", "popular")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concerts").isArray())
-                .andExpect(jsonPath("$.concerts").isNotEmpty())
-                .andExpect(jsonPath("$.concerts[0].title").value("BLACKPINK 월드투어 [Born Pink]"))
-                .andExpect(jsonPath("$.concerts[1].title").value("BTS 월드투어 [Yet To Come]"))
-                .andExpect(jsonPath("$.concerts[2].title").value("아이유 콘서트 [The Golden Hour]"));
+    void getConcerts_PopularSort_API_Integration() {
+        // when
+        ResponseEntity<ConcertListResponse> response = restTemplate.exchange(
+                "/api/concerts?page=0&size=10&sort=popular",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertListResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getConcerts()).isNotEmpty();
+        assertThat(response.getBody().getConcerts().get(0).getTitle()).isEqualTo("BLACKPINK 월드투어 [Born Pink]");
+        assertThat(response.getBody().getConcerts().get(1).getTitle()).isEqualTo("BTS 월드투어 [Yet To Come]");
+        assertThat(response.getBody().getConcerts().get(2).getTitle()).isEqualTo("아이유 콘서트 [The Golden Hour]");
     }
 
     @Test
     @DisplayName("공연 목록 조회 API 통합 테스트 - 최신순 정렬")
-    void getConcerts_LatestSort_API_Integration() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/concerts")
-                        .param("page", "0")
-                        .param("size", "10")
-                        .param("sort", "latest")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concerts").isArray())
-                .andExpect(jsonPath("$.concerts").isNotEmpty())
-                .andExpect(jsonPath("$.concerts[0].title").value("아이유 콘서트 [The Golden Hour]"))
-                .andExpect(jsonPath("$.concerts[1].title").value("BTS 월드투어 [Yet To Come]"))
-                .andExpect(jsonPath("$.concerts[2].title").value("BLACKPINK 월드투어 [Born Pink]"))
-                .andExpect(jsonPath("$.totalElements").value(3));
+    void getConcerts_LatestSort_API_Integration() {
+        // when
+        ResponseEntity<ConcertListResponse> response = restTemplate.exchange(
+                "/api/concerts?page=0&size=10&sort=latest",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertListResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getConcerts()).isNotEmpty();
+        assertThat(response.getBody().getConcerts().get(0).getTitle()).isEqualTo("아이유 콘서트 [The Golden Hour]");
+        assertThat(response.getBody().getConcerts().get(1).getTitle()).isEqualTo("BTS 월드투어 [Yet To Come]");
+        assertThat(response.getBody().getConcerts().get(2).getTitle()).isEqualTo("BLACKPINK 월드투어 [Born Pink]");
+        assertThat(response.getBody().getTotalElements()).isEqualTo(3);
     }
 
     @Test
     @DisplayName("공연 상세 조회 API 통합 테스트 - 성공")
-    void getConcertDetail_Success_API_Integration() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/concerts/1")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concertId").value(1))
-                .andExpect(jsonPath("$.title").value("아이유 콘서트 [The Golden Hour]"))
-                .andExpect(jsonPath("$.categoryName").value("콘서트"))
-                .andExpect(jsonPath("$.hallName").value("올림픽공원 KSPO DOME"))
-                .andExpect(jsonPath("$.ageLimit").value("전체관람가"))
-                .andExpect(jsonPath("$.description").value("아이유의 따뜻한 목소리로 전하는 골든 아워 콘서트. 새로운 앨범의 감동을 라이브로 만나보세요"))
-                .andExpect(jsonPath("$.runningTime").value(150))
-                .andExpect(jsonPath("$.status").value("ACTIVE"))
-                // 연관 데이터 검증
-                .andExpect(jsonPath("$.concertFiles").isArray())
-                .andExpect(jsonPath("$.concertFiles").isNotEmpty())
-                .andExpect(jsonPath("$.concertFiles[0].fileType").value("POSTER"))
-                .andExpect(jsonPath("$.schedules").isArray())
-                .andExpect(jsonPath("$.schedules").isNotEmpty())
-                .andExpect(jsonPath("$.seatPrices").isArray())
-                .andExpect(jsonPath("$.seatPrices").isNotEmpty())
-                .andExpect(jsonPath("$.seatPrices[?(@.seatGrade == 'VIP')].price").value(220000.00))
-                .andExpect(jsonPath("$.seatPrices[?(@.seatGrade == 'R석')].price").value(170000.00))
-                .andExpect(jsonPath("$.seatPrices[?(@.seatGrade == 'S석')].price").value(130000.00));
+    void getConcertDetail_Success_API_Integration() {
+        // when
+        ResponseEntity<ConcertDetailResponse> response = restTemplate.exchange(
+                "/api/concerts/1",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertDetailResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        
+        ConcertDetailResponse concert = response.getBody();
+        assertThat(concert.getConcertId()).isEqualTo(1);
+        assertThat(concert.getTitle()).isEqualTo("아이유 콘서트 [The Golden Hour]");
+        assertThat(concert.getCategoryName()).isEqualTo("콘서트");
+        assertThat(concert.getHallName()).isEqualTo("올림픽공원 KSPO DOME");
+        assertThat(concert.getAgeLimit()).isEqualTo("전체관람가");
+        assertThat(concert.getDescription()).isEqualTo("아이유의 따뜻한 목소리로 전하는 골든 아워 콘서트. 새로운 앨범의 감동을 라이브로 만나보세요");
+        assertThat(concert.getRunningTime()).isEqualTo(150);
+        assertThat(concert.getStatus()).isEqualTo("ACTIVE");
+        
+        // 연관 데이터 검증
+        assertThat(concert.getConcertFiles()).isNotEmpty();
+        assertThat(concert.getConcertFiles().get(0).getFileType()).isEqualTo("POSTER");
+        assertThat(concert.getSchedules()).isNotEmpty();
+        assertThat(concert.getSeatPrices()).isNotEmpty();
+        
+        // 좌석 가격 검증
+        assertThat(concert.getSeatPrices())
+                .extracting("seatGrade", "price")
+                .contains(
+                    tuple("VIP", new BigDecimal("220000.00")),
+                    tuple("R석", new BigDecimal("170000.00")),
+                    tuple("S석", new BigDecimal("130000.00"))
+                );
     }
 
     @Test
     @DisplayName("공연 상세 조회 API 통합 테스트 - 존재하지 않는 공연")
-    void getConcertDetail_NotFound_API_Integration() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/concerts/999")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isNotFound())
-                .andExpect(content().string("콘서트를 찾을 수 없습니다. ID: 999"));
+    void getConcertDetail_NotFound_API_Integration() {
+        // when
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/concerts/999",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                String.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isEqualTo("콘서트를 찾을 수 없습니다. ID: 999");
     }
 
     @Test
     @DisplayName("페이징 API 통합 테스트")
-    void getConcerts_Paging_API_Integration() throws Exception {
-        // when & then - 첫 번째 페이지
-        mockMvc.perform(get("/api/concerts")
-                        .param("page", "0")
-                        .param("size", "2")
-                        .param("sort", "upcoming")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concerts").isArray())
-                .andExpect(jsonPath("$.concerts.length()").value(2))
-                .andExpect(jsonPath("$.currentPage").value(0))
-                .andExpect(jsonPath("$.pageSize").value(2))
-                .andExpect(jsonPath("$.totalElements").value(3))
-                .andExpect(jsonPath("$.totalPages").value(2));
+    void getConcerts_Paging_API_Integration() {
+        // when - 첫 번째 페이지
+        ResponseEntity<ConcertListResponse> firstPageResponse = restTemplate.exchange(
+                "/api/concerts?page=0&size=2&sort=upcoming",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertListResponse.class
+        );
 
-        // when & then - 두 번째 페이지
-        mockMvc.perform(get("/api/concerts")
-                        .param("page", "1")
-                        .param("size", "2")
-                        .param("sort", "upcoming")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concerts").isArray())
-                .andExpect(jsonPath("$.concerts.length()").value(1))
-                .andExpect(jsonPath("$.currentPage").value(1))
-                .andExpect(jsonPath("$.pageSize").value(2));
+        // then - 첫 번째 페이지
+        assertThat(firstPageResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(firstPageResponse.getBody()).isNotNull();
+        assertThat(firstPageResponse.getBody().getConcerts()).hasSize(2);
+        assertThat(firstPageResponse.getBody().getCurrentPage()).isEqualTo(0);
+        assertThat(firstPageResponse.getBody().getPageSize()).isEqualTo(2);
+        assertThat(firstPageResponse.getBody().getTotalElements()).isEqualTo(3);
+        assertThat(firstPageResponse.getBody().getTotalPages()).isEqualTo(2);
+
+        // when - 두 번째 페이지
+        ResponseEntity<ConcertListResponse> secondPageResponse = restTemplate.exchange(
+                "/api/concerts?page=1&size=2&sort=upcoming",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertListResponse.class
+        );
+
+        // then - 두 번째 페이지
+        assertThat(secondPageResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(secondPageResponse.getBody()).isNotNull();
+        assertThat(secondPageResponse.getBody().getConcerts()).hasSize(1);
+        assertThat(secondPageResponse.getBody().getCurrentPage()).isEqualTo(1);
+        assertThat(secondPageResponse.getBody().getPageSize()).isEqualTo(2);
     }
 
     @Test
     @DisplayName("잘못된 정렬 타입 API 통합 테스트 - SortType.fromValue에서 기본값(UPCOMING)으로 처리됨")
-    void getConcerts_InvalidSortType_API_Integration() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/concerts")
-                        .param("page", "0")
-                        .param("size", "10")
-                        .param("sort", "invalid_sort")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.concerts").isArray())
-                .andExpect(jsonPath("$.concerts").isNotEmpty())
-                .andExpect(jsonPath("$.totalElements").value(3));
+    void getConcerts_InvalidSortType_API_Integration() {
+        // when
+        ResponseEntity<ConcertListResponse> response = restTemplate.exchange(
+                "/api/concerts?page=0&size=10&sort=invalid_sort",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                ConcertListResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getConcerts()).isNotEmpty();
+        assertThat(response.getBody().getTotalElements()).isEqualTo(3);
     }
 
     @Test
     @DisplayName("좌석 조회 API 통합 테스트 - 성공")
-    void getAvailableSeats_Success_API_Integration() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/concerts/schedules/1/seats")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.scheduleId").value(1))
-                .andExpect(jsonPath("$.availableSeats").isArray())
-                .andExpect(jsonPath("$.availableSeats").isNotEmpty())
-                // 첫 번째 좌석 정보 검증
-                .andExpect(jsonPath("$.availableSeats[0].seatGrade").exists())
-                .andExpect(jsonPath("$.availableSeats[0].block").exists())
-                .andExpect(jsonPath("$.availableSeats[0].seatRow").exists())
-                .andExpect(jsonPath("$.availableSeats[0].seatNumber").exists())
-                .andExpect(jsonPath("$.availableSeats[0].price").exists())
-                // 좌석 등급별 검증
-                .andExpect(jsonPath("$.availableSeats[?(@.seatGrade == 'VIP')]").exists())
-                .andExpect(jsonPath("$.availableSeats[?(@.seatGrade == 'R석')]").exists())
-                .andExpect(jsonPath("$.availableSeats[?(@.seatGrade == 'S석')]").exists());
+    void getAvailableSeats_Success_API_Integration() {
+        // when
+        ResponseEntity<AvailableSeatsResponse> response = restTemplate.exchange(
+                "/api/concerts/schedules/1/seats",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                AvailableSeatsResponse.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        
+        AvailableSeatsResponse seatsResponse = response.getBody();
+        assertThat(seatsResponse.getScheduleId()).isEqualTo(1);
+        assertThat(seatsResponse.getAvailableSeats()).isNotEmpty();
+        
+        // 첫 번째 좌석 정보 검증
+        assertThat(seatsResponse.getAvailableSeats().get(0).getSeatGrade()).isNotNull();
+        assertThat(seatsResponse.getAvailableSeats().get(0).getBlock()).isNotNull();
+        assertThat(seatsResponse.getAvailableSeats().get(0).getSeatRow()).isNotNull();
+        assertThat(seatsResponse.getAvailableSeats().get(0).getSeatNumber()).isNotNull();
+        assertThat(seatsResponse.getAvailableSeats().get(0).getPrice()).isNotNull();
+        
+        // 좌석 등급별 검증
+        assertThat(seatsResponse.getAvailableSeats())
+                .extracting("seatGrade")
+                .contains("VIP", "R석", "S석");
     }
 
     @Test
     @DisplayName("좌석 조회 API 통합 테스트 - 다양한 스케줄의 좌석 조회")
-    void getAvailableSeats_MultipleSchedules_API_Integration() throws Exception {
+    void getAvailableSeats_MultipleSchedules_API_Integration() {
         // when & then - 첫 번째 스케줄 좌석 조회
-        mockMvc.perform(get("/api/concerts/schedules/1/seats")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.scheduleId").value(1))
-                .andExpect(jsonPath("$.allSeats").isArray())
-                .andExpect(jsonPath("$.availableSeats").isArray());
+        ResponseEntity<AvailableSeatsResponse> response1 = restTemplate.exchange(
+                "/api/concerts/schedules/1/seats",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                AvailableSeatsResponse.class
+        );
+
+        assertThat(response1.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response1.getBody()).isNotNull();
+        assertThat(response1.getBody().getScheduleId()).isEqualTo(1);
+        assertThat(response1.getBody().getAllSeats()).isNotEmpty();
+        assertThat(response1.getBody().getAvailableSeats()).isNotEmpty();
 
         // when & then - 두 번째 스케줄 좌석 조회
-        mockMvc.perform(get("/api/concerts/schedules/2/seats")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.scheduleId").value(2))
-                .andExpect(jsonPath("$.allSeats").isArray())
-                .andExpect(jsonPath("$.availableSeats").isArray());
+        ResponseEntity<AvailableSeatsResponse> response2 = restTemplate.exchange(
+                "/api/concerts/schedules/2/seats",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                AvailableSeatsResponse.class
+        );
+
+        assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response2.getBody()).isNotNull();
+        assertThat(response2.getBody().getScheduleId()).isEqualTo(2);
+        assertThat(response2.getBody().getAllSeats()).isNotEmpty();
+        assertThat(response2.getBody().getAvailableSeats()).isNotEmpty();
 
         // when & then - 세 번째 스케줄 좌석 조회
-        mockMvc.perform(get("/api/concerts/schedules/3/seats")
-                        .header("X-QUEUE-TOKEN", QUEUE_TOKEN))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.scheduleId").value(3))
-                .andExpect(jsonPath("$.allSeats").isArray())
-                .andExpect(jsonPath("$.availableSeats").isArray());
+        ResponseEntity<AvailableSeatsResponse> response3 = restTemplate.exchange(
+                "/api/concerts/schedules/3/seats",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                AvailableSeatsResponse.class
+        );
+
+        assertThat(response3.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response3.getBody()).isNotNull();
+        assertThat(response3.getBody().getScheduleId()).isEqualTo(3);
+        assertThat(response3.getBody().getAllSeats()).isNotEmpty();
+        assertThat(response3.getBody().getAvailableSeats()).isNotEmpty();
     }
 }


### PR DESCRIPTION
### 주요 변경 사항

- 기존 동기 방식의 `ConcertController`를 `CompletableFuture` 기반으로 전환하여 **비동기 HTTP 응답 처리**를 구현했습니다.
- 모든 컨트롤러 메서드가 `CompletableFuture<ResponseEntity<...>>`를 반환하도록 리팩토링되었습니다.
- 기존 `AvailableSeatsResponse.from(...)` 로직에서 `CompletableFuture.join()`을 사용해 두 작업을 **동기적으로 대기**하던 구조를 제거했습니다.

### 상세 변경 내용

- `getConcerts`, `getConcertDetail` 메서드: `supplyAsync()` → `thenApply(ResponseEntity::ok)` 방식으로 변환
- `getAvailableSeats`: 내부에서 `CompletableFuture<CompletableFuture<AvailableSeatsResponse>>` 형태가 발생하기 때문에  
  `thenCompose()`를 사용하여 중첩 구조를 평탄화 후 `ResponseEntity` 래핑 처리
- `join()`대신, `thenCombine()`을 적용하여 **두 Future가 모두 완료되었을 때 비동기적으로 결합**하는 구조로 개선했습니다.

### 기대 효과

- 향후 대규모 트래픽 환경에서 **컨트롤러 단의 처리량 향상**
- 특히 좌석 정보 조회와 같이 병렬 처리가 이루어지는 요청에서 응답 속도 개선 가능
- 응답 구조는 기존과 동일하므로 **클라이언트 영향 없음**
