### PR TITLE
[콘서트 예약 시스템] 좌석 예약 API 개발(kafka 적용)

### DIFF
--- a/zariyo-main/build.gradle
+++ b/zariyo-main/build.gradle
@@ -16,5 +16,8 @@ dependencies {
 
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.testcontainers:mysql'
 }

--- a/zariyo-main/src/main/java/com/zariyo/common/config/KafkaConfig.java
+++ b/zariyo-main/src/main/java/com/zariyo/common/config/KafkaConfig.java
@@ -1,0 +1,81 @@
+package com.zariyo.common.config;
+
+import com.zariyo.concert.application.consumer.event.ReservationRequestEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ProducerFactory<String, ReservationRequestEvent> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all"); // 모든 복제본 확인 후 응답
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 3);  // 실패 시 3번 재시도
+        configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true); // 중복 제거
+        configProps.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5); // 순서 보장
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ReservationRequestEvent> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, ReservationRequestEvent> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+
+        configProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"); // 처음부터 읽기
+        configProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);     // 수동 커밋
+        configProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);         // 한 번에 처리할 메시지 수 (예약 처리량에 맞게 조정)
+
+        // JSON 역직렬화 신뢰 패키지 설정
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES,
+                "com.zariyo.concert.application.consumer.event");
+
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ReservationRequestEvent> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ReservationRequestEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        // 동시 처리 설정
+        factory.setConcurrency(3); // 3개 컨슈머 스레드로 병렬 처리
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD); // 레코드별 ACK
+
+        return factory;
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/ReservationController.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/ReservationController.java
@@ -1,0 +1,28 @@
+package com.zariyo.concert.api;
+
+import com.zariyo.concert.api.request.ReservationRequest;
+import com.zariyo.concert.api.response.ReservationStatusResponse;
+import com.zariyo.concert.api.response.ReservationTokenResponse;
+import com.zariyo.concert.application.facade.ConcertFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.CompletableFuture;
+
+@RestController
+@RequestMapping("/api/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+    private final ConcertFacade concertFacade;
+
+    @PostMapping
+    public CompletableFuture<ResponseEntity<ReservationTokenResponse>>concertSeatsReservation(@RequestBody ReservationRequest request) {
+        return concertFacade.reserveSeats(request.getSeatIds()).thenApply(ResponseEntity::ok);
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<ReservationStatusResponse> checkReservationStatus(@RequestParam String token) {
+        return ResponseEntity.ok(concertFacade.getReservationStatus(token));
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/request/ReservationRequest.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/request/ReservationRequest.java
@@ -1,0 +1,16 @@
+package com.zariyo.concert.api.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationRequest {
+    private List<Long> seatIds;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/ReservationStatusResponse.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/ReservationStatusResponse.java
@@ -1,0 +1,42 @@
+package com.zariyo.concert.api.response;
+
+import com.zariyo.concert.application.dto.ReservationStatusDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationStatusResponse {
+    private String reservationToken;
+    private String status;
+    private String message;
+    private LocalDateTime timestamp;
+    private String redirectUrl;
+
+    public static ReservationStatusResponse from(ReservationStatusDto statusDto) {
+        return ReservationStatusResponse.builder()
+                .reservationToken(statusDto.getReservationToken())
+                .status(statusDto.getStatus())
+                .message(statusDto.getMessage())
+                .timestamp(statusDto.getTimestamp())
+                .redirectUrl("/api/reservations/status?token=" + statusDto.getReservationToken())
+                .build();
+    }
+
+    public static ReservationStatusResponse nullResponse(String token) {
+        return ReservationStatusResponse.builder()
+                .reservationToken(token)
+                .status("PROCESSING")
+                .message("예약 중 입니다.")
+                .timestamp(LocalDateTime.now())
+                .redirectUrl("/api/reservations/status?token=" + token)
+                .build();
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/api/response/ReservationTokenResponse.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/api/response/ReservationTokenResponse.java
@@ -1,0 +1,15 @@
+package com.zariyo.concert.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationTokenResponse {
+    private String token;
+    private String redirectUrl;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/consumer/ReservationConsumer.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/consumer/ReservationConsumer.java
@@ -1,0 +1,20 @@
+package com.zariyo.concert.application.consumer;
+
+import com.zariyo.concert.application.consumer.event.ReservationRequestEvent;
+import com.zariyo.concert.application.service.ReservationService;
+import com.zariyo.concert.domain.entity.ScheduleSeat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationConsumer {
+
+    private final ReservationService reservationService;
+
+    @KafkaListener(topics = "reservation-requests", groupId = "zariyo-group")
+    public void consumeReservationRequest(ReservationRequestEvent event) {
+        reservationService.updateSeatHold(event.getSeatIds());
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/consumer/event/ReservationRequestEvent.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/consumer/event/ReservationRequestEvent.java
@@ -1,0 +1,19 @@
+package com.zariyo.concert.application.consumer.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationRequestEvent {
+    private String reservationToken;
+    private List<Long> seatIds;
+    private String eventType;
+    private long timestamp;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/dto/OutboxDTO.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/dto/OutboxDTO.java
@@ -1,0 +1,22 @@
+package com.zariyo.concert.application.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OutboxDTO {
+    private Long seatsOutboxId;
+    private String reservationToken;
+    private String payload;
+    private OutboxStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime sentAt;
+
+    public enum OutboxStatus {
+        PENDING, SENT, FAILED
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/dto/ReservationStatusDto.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/dto/ReservationStatusDto.java
@@ -1,0 +1,17 @@
+package com.zariyo.concert.application.dto;
+
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationStatusDto {
+    private String reservationToken;
+    private String status;
+    private String message;
+    private LocalDateTime timestamp;
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/producer/SeatsOutboxProducer.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/producer/SeatsOutboxProducer.java
@@ -1,0 +1,84 @@
+package com.zariyo.concert.application.producer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zariyo.concert.application.consumer.event.ReservationRequestEvent;
+import com.zariyo.concert.domain.entity.ScheduleSeat;
+import com.zariyo.concert.domain.entity.SeatsOutbox;
+import com.zariyo.concert.domain.repository.ScheduleSeatRepository;
+import com.zariyo.concert.infra.SeatsOutboxJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatsOutboxProducer {
+
+    private final KafkaTemplate<String, ReservationRequestEvent> kafkaTemplate;
+    private final SeatsOutboxJpaRepository seatsOutboxJpaRepository;
+    private final ScheduleSeatRepository scheduleSeatRepository;
+    private final ObjectMapper objectMapper;
+
+    public void sendToKafkaAsync(SeatsOutbox outbox) {
+        try {
+            ReservationRequestEvent event = createKafkaEvent(outbox);
+                
+            kafkaTemplate.send("reservation-requests", outbox.getReservationToken(), event)
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            updateOutboxToSent(outbox);
+                        } else {
+                            handleKafkaFailure(outbox);
+                        }
+                    });
+        } catch (Exception e) {
+            handleKafkaFailure(outbox);
+        }
+    }
+
+    private ReservationRequestEvent createKafkaEvent(SeatsOutbox outbox) {
+        try {
+            List<Long> seatIds = objectMapper.readValue(
+                outbox.getSeatIds(), new TypeReference<List<Long>>() {});
+
+            return ReservationRequestEvent.builder()
+                .reservationToken(outbox.getReservationToken())
+                .seatIds(seatIds)
+                .timestamp(System.currentTimeMillis())
+                .build();
+        } catch (Exception e) {
+            log.error("Kafka 이벤트 생성 실패: token={}", outbox.getReservationToken(), e);
+            throw new RuntimeException("Kafka 이벤트 생성 실패", e);
+        }
+    }
+
+    private void updateOutboxToSent(SeatsOutbox outbox) {
+        try {
+            outbox.markAsSent();
+            seatsOutboxJpaRepository.save(outbox);
+        } catch (Exception e) {
+            log.error("Outbox 상태 업데이트 실패: ReservationToken={}", outbox.getReservationToken(), e);
+        }
+    }
+
+    private void handleKafkaFailure(SeatsOutbox outbox) {
+        try {
+            List<Long> seatIds = objectMapper.readValue(
+                outbox.getSeatIds(), new TypeReference<List<Long>>() {});
+
+            scheduleSeatRepository.findAllById(seatIds).forEach(ScheduleSeat::hold);
+            
+            outbox.markAsFailed();
+            seatsOutboxJpaRepository.save(outbox);
+            
+            log.error("Kafka 전송 실패 - 직접 DB 업데이트 수행: token={}", outbox.getReservationToken());
+        } catch (Exception ex) {
+            log.error("Kafka 전송 실패 처리 중 추가 오류: ReservationToken={}", outbox.getReservationToken(), ex);
+        }
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/scheduler/SeatExpiryScheduler.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/scheduler/SeatExpiryScheduler.java
@@ -1,0 +1,56 @@
+package com.zariyo.concert.application.scheduler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zariyo.concert.application.producer.SeatsOutboxProducer;
+import com.zariyo.concert.domain.entity.ScheduleSeat;
+import com.zariyo.concert.domain.entity.SeatsOutbox;
+import com.zariyo.concert.domain.repository.ScheduleSeatRepository;
+import com.zariyo.concert.infra.SeatReservationRedisRepository;
+import com.zariyo.concert.infra.SeatsOutboxJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SeatExpiryScheduler {
+
+    private final SeatReservationRedisRepository seatReservationRedisRepository;
+    private final ScheduleSeatRepository scheduleSeatRepository;
+    @Scheduled(fixedDelay = 10000)
+    public void checkExpiredSeats() {
+        try {
+            Set<String> expiredSeatKeys = seatReservationRedisRepository.getExpiredSeatKeys();
+
+            if (!expiredSeatKeys.isEmpty()) {
+                List<Long> expiredSeatIds = expiredSeatKeys.stream()
+                        .map(key -> key.replace("seat:hold:", ""))
+                        .map(Long::valueOf)
+                        .collect(Collectors.toList());
+
+                SeatReservationRelease(expiredSeatIds);
+
+                seatReservationRedisRepository.removeFromExpirySchedule(
+                        expiredSeatKeys.toArray(new String[0]));
+            }
+        } catch (Exception e) {
+            log.error("좌석 만료 처리 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 좌석 해제
+     */
+    private void SeatReservationRelease(List<Long> seatIds) {
+        scheduleSeatRepository.findAllById(seatIds).forEach(ScheduleSeat::release);
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/application/service/ReservationService.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/application/service/ReservationService.java
@@ -1,0 +1,71 @@
+package com.zariyo.concert.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zariyo.concert.application.dto.ReservationStatusDto;
+import com.zariyo.concert.application.producer.SeatsOutboxProducer;
+import com.zariyo.concert.domain.entity.ScheduleSeat;
+import com.zariyo.concert.domain.entity.SeatsOutbox;
+import com.zariyo.concert.domain.repository.ScheduleSeatRepository;
+import com.zariyo.concert.infra.ReservationStatusRedisRepository;
+import com.zariyo.concert.infra.SeatReservationRedisRepository;
+import com.zariyo.concert.infra.SeatsOutboxJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+    private final SeatsOutboxJpaRepository seatsOutboxJpaRepository;
+    private final ScheduleSeatRepository scheduleSeatRepository;
+    private final SeatReservationRedisRepository seatReservationRedisRepository;
+    private final ReservationStatusRedisRepository reservationStatusRedisRepository;
+
+    private final SeatsOutboxProducer seatsOutboxProducer;
+    private final ObjectMapper objectMapper;
+
+    private String createReservationPayload(List<Long> seatIds) {
+        try {
+            return objectMapper.writeValueAsString(seatIds);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize seat IDs", e);
+        }
+    }
+
+    @Transactional
+    public void reserveSeats(List<Long> seatIds, String reservationToken) {
+
+        boolean seatReservationSuccess = seatReservationRedisRepository.attemptSeatReservation(seatIds, reservationToken);
+
+        if (seatReservationSuccess) {
+            SeatsOutbox outbox = SeatsOutbox.builder()
+                    .reservationToken(reservationToken)
+                    .seatIds(createReservationPayload(seatIds))
+                    .status(SeatsOutbox.OutboxStatus.PENDING)
+                    .build();
+            SeatsOutbox savedOutbox = seatsOutboxJpaRepository.save(outbox);
+
+            reservationStatusRedisRepository.setReservationStatus(
+                    reservationToken, "SUCCESS", "좌석 예약이 완료되었습니다.");
+
+            seatsOutboxProducer.sendToKafkaAsync(savedOutbox);
+        } else {
+            reservationStatusRedisRepository.setReservationStatus(
+                    reservationToken, "FAILED", "이미 예약된 좌석이 포함되어 있습니다.");
+        }
+    }
+
+    @Transactional
+    public void updateSeatHold(List<Long> seatIds) {
+        scheduleSeatRepository.findAllById(seatIds).forEach(ScheduleSeat::hold);
+    }
+
+    public ReservationStatusDto getReservationStatus(String reservationToken) {
+        return reservationStatusRedisRepository.getReservationStatus(reservationToken);
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/config/ReservationLuaScriptManager.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/config/ReservationLuaScriptManager.java
@@ -1,0 +1,51 @@
+package com.zariyo.concert.config;
+
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationLuaScriptManager {
+
+    private final Map<String, DefaultRedisScript<?>> scripts = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        loadScript("reserveSeats", "lua/reserveSeats.lua", Boolean.class);
+    }
+
+    private <T> void loadScript(String key, String path, Class<T> resultType) {
+        try {
+            Resource resource = new ClassPathResource(path);
+            String lua = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            DefaultRedisScript<T> script = new DefaultRedisScript<>();
+            script.setScriptText(lua);
+            script.setResultType(resultType);
+            scripts.put(key, script);
+        } catch (IOException e) {
+            log.error("스크립트 로드 실패: {}", key, e);
+            throw new RuntimeException("스크립트 로드 실패: " + key, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> DefaultRedisScript<T> getScript(String key, Class<T> resultType) {
+        DefaultRedisScript<T> script = (DefaultRedisScript<T>) scripts.get(key);
+        if (script == null) {
+            throw new IllegalArgumentException("스크립트 없음: " + key);
+        }
+        return script;
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/domain/entity/ScheduleSeat.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/domain/entity/ScheduleSeat.java
@@ -43,4 +43,25 @@ public class ScheduleSeat {
     public enum SeatStatus {
         AVAILABLE, PENDING, RESERVED
     }
+
+    /**
+     * 좌석 예약 처리
+     */
+    public void reserve() {
+        this.status = SeatStatus.RESERVED;
+    }
+
+    /**
+     * 좌석 선점 처리
+     */
+    public void hold() {
+        this.status = SeatStatus.PENDING;
+    }
+
+    /**
+     * 좌석 해제 (사용 가능 상태로 복구)
+     */
+    public void release() {
+        this.status = SeatStatus.AVAILABLE;
+    }
 }

--- a/zariyo-main/src/main/java/com/zariyo/concert/domain/entity/SeatsOutbox.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/domain/entity/SeatsOutbox.java
@@ -1,0 +1,51 @@
+package com.zariyo.concert.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "seats_outbox")
+public class SeatsOutbox {
+
+    @Id
+    @Column(name = "reservation_token", nullable = false)
+    private String reservationToken;
+
+    @Column(name = "seat_ids", columnDefinition = "JSON", nullable = false)
+    private String seatIds;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Builder.Default
+    private OutboxStatus status = OutboxStatus.PENDING;
+
+    @Column(name = "created_at", nullable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    public enum OutboxStatus {
+        PENDING, SENT, FAILED
+    }
+
+    public void markAsSent() {
+        this.status = OutboxStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed() {
+        this.status = OutboxStatus.FAILED;
+        this.sentAt = LocalDateTime.now();
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/domain/repository/ScheduleSeatRepository.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/domain/repository/ScheduleSeatRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface ScheduleSeatRepository {
     List<ScheduleSeat> findAvailableSeatsByScheduleId(Long scheduleId);
     List<ScheduleSeat> findAllSeatsByScheduleId(Long scheduleId);
+
+    List<ScheduleSeat> findAllById(List<Long> seatIds);
 }

--- a/zariyo-main/src/main/java/com/zariyo/concert/infra/ReservationStatusRedisRepository.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/infra/ReservationStatusRedisRepository.java
@@ -1,0 +1,62 @@
+package com.zariyo.concert.infra;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zariyo.concert.application.dto.ReservationStatusDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ReservationStatusRedisRepository {
+
+    private final StringRedisTemplate mainRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String RESERVATION_STATUS_PREFIX = "reservation:status:";
+    private static final Duration STATUS_TTL = Duration.ofMinutes(10);
+
+    /**
+     * 예약 상태 저장 (성공/실패/처리중)
+     */
+    public void setReservationStatus(String reservationToken, String status, String message) {
+        try {
+            ReservationStatusDto statusDto = ReservationStatusDto.builder()
+                    .reservationToken(reservationToken)
+                    .status(status)
+                    .message(message)
+                    .timestamp(LocalDateTime.now())
+                    .build();
+
+            String statusKey = RESERVATION_STATUS_PREFIX + reservationToken;
+            mainRedisTemplate.opsForValue().set(
+                    statusKey,
+                    objectMapper.writeValueAsString(statusDto),
+                    STATUS_TTL
+            );
+
+            log.info("예약 상태 저장: token={}, status={}", reservationToken, status);
+        } catch (Exception e) {
+            log.error("예약 상태 저장 실패: token={}", reservationToken, e);
+        }
+    }
+
+    /**
+     * 예약 상태 조회
+     */
+    public ReservationStatusDto getReservationStatus(String reservationToken) {
+        try {
+            String statusKey = RESERVATION_STATUS_PREFIX + reservationToken;
+            String statusJson = mainRedisTemplate.opsForValue().get(statusKey);
+            return objectMapper.readValue(statusJson, ReservationStatusDto.class);
+        } catch (Exception e) {
+            log.error("예약 상태 조회 실패: token={}", reservationToken, e);
+            return null;
+        }
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/infra/ScheduleSeatRepositoryImpl.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/infra/ScheduleSeatRepositoryImpl.java
@@ -22,4 +22,9 @@ public class ScheduleSeatRepositoryImpl implements ScheduleSeatRepository {
     public List<ScheduleSeat> findAllSeatsByScheduleId(Long scheduleId) {
         return scheduleSeatJpaRepository.findAllSeatsByScheduleId(scheduleId);
     }
+
+    @Override
+    public List<ScheduleSeat> findAllById(List<Long> seatIds) {
+        return scheduleSeatJpaRepository.findAllById(seatIds);
+    }
 }

--- a/zariyo-main/src/main/java/com/zariyo/concert/infra/SeatReservationRedisRepository.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/infra/SeatReservationRedisRepository.java
@@ -1,0 +1,58 @@
+package com.zariyo.concert.infra;
+
+import com.zariyo.concert.config.ReservationLuaScriptManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class SeatReservationRedisRepository {
+
+
+    private final StringRedisTemplate mainRedisTemplate;
+    private final ReservationLuaScriptManager luaScriptManager;
+
+    private static final String SEAT_HOLD_PREFIX = "seat:hold:";
+    private static final String SEAT_EXPIRY_SCHEDULE_KEY = "seat:expiry:schedule";
+    private static final int SEAT_TTL_MINUTES = 5;
+
+    /**
+     * 좌석 선점 시도
+     */
+    public boolean attemptSeatReservation(List<Long> seatIds, String reservationToken) {
+        List<String> keys = seatIds.stream()
+                .map(id -> SEAT_HOLD_PREFIX + id)
+                .collect(Collectors.toList());
+
+        return Boolean.TRUE.equals(mainRedisTemplate.execute(
+                luaScriptManager.getScript("reserveSeats", Boolean.class),
+                keys,
+                reservationToken,
+                String.valueOf(SEAT_TTL_MINUTES * 60),
+                String.valueOf(System.currentTimeMillis())
+        ));
+    }
+
+    /**
+     * 만료된 좌석 목록 조회
+     */
+    public Set<String> getExpiredSeatKeys() {
+        long currentTime = System.currentTimeMillis();
+        return mainRedisTemplate.opsForZSet()
+                .rangeByScore(SEAT_EXPIRY_SCHEDULE_KEY, 0, currentTime);
+    }
+
+    /**
+     * 만료 스케줄에서 좌석 제거
+     */
+    public void removeFromExpirySchedule(String[] seatKeys) {
+        mainRedisTemplate.opsForZSet().remove(SEAT_EXPIRY_SCHEDULE_KEY, (Object[]) seatKeys);
+    }
+}

--- a/zariyo-main/src/main/java/com/zariyo/concert/infra/SeatsOutboxJpaRepository.java
+++ b/zariyo-main/src/main/java/com/zariyo/concert/infra/SeatsOutboxJpaRepository.java
@@ -1,0 +1,11 @@
+package com.zariyo.concert.infra;
+
+import com.zariyo.concert.domain.entity.SeatsOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SeatsOutboxJpaRepository extends JpaRepository<SeatsOutbox, String> {
+
+    Optional<SeatsOutbox> findByReservationToken(String reservationToken);
+}

--- a/zariyo-main/src/main/resources/application.yml
+++ b/zariyo-main/src/main/resources/application.yml
@@ -21,3 +21,34 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      retries: 3
+      batch-size: 16384
+      linger-ms: 5
+      buffer-memory: 33554432
+      properties:
+        enable.idempotence: true
+        max.in.flight.requests.per.connection: 5
+    consumer:
+      group-id: reservation-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      max-poll-records: 100
+      fetch-min-size: 1
+      fetch-max-wait: 500
+      properties:
+        spring.json.trusted.packages: "com.zariyo.concert.application.consumer.event"
+        session.timeout.ms: 30000
+        heartbeat.interval.ms: 10000
+    listener:
+      ack-mode: record
+      concurrency: 3
+      poll-timeout: 3000

--- a/zariyo-main/src/main/resources/lua/reserveSeats.lua
+++ b/zariyo-main/src/main/resources/lua/reserveSeats.lua
@@ -1,0 +1,25 @@
+local reservation_token = ARGV[1]
+local ttl_seconds = tonumber(ARGV[2])
+local timestamp = tonumber(ARGV[3])
+local success = true
+
+for i = 1, #KEYS do
+    if redis.call('EXISTS', KEYS[i]) == 1 then
+        success = false
+        break
+    end
+end
+
+if success then
+    local seat_data = reservation_token .. ':' .. timestamp
+
+    for i = 1, #KEYS do
+        -- 좌석 선점 저장
+        redis.call('SETEX', KEYS[i], ttl_seconds, seat_data)
+        -- TTL 만료 감지를 위한 스케줄 등록
+        local expire_time = timestamp + (ttl_seconds * 1000)
+        redis.call('ZADD', 'seat:expiry:schedule', expire_time, KEYS[i])
+    end
+end
+
+return success

--- a/zariyo-main/src/test/java/com/zariyo/concert/application/service/ReservationServiceTest.java
+++ b/zariyo-main/src/test/java/com/zariyo/concert/application/service/ReservationServiceTest.java
@@ -1,0 +1,225 @@
+package com.zariyo.concert.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zariyo.concert.application.dto.ReservationStatusDto;
+import com.zariyo.concert.application.producer.SeatsOutboxProducer;
+import com.zariyo.concert.domain.entity.ScheduleSeat;
+import com.zariyo.concert.domain.entity.SeatsOutbox;
+import com.zariyo.concert.domain.repository.ScheduleSeatRepository;
+import com.zariyo.concert.infra.ReservationStatusRedisRepository;
+import com.zariyo.concert.infra.SeatReservationRedisRepository;
+import com.zariyo.concert.infra.SeatsOutboxJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    @Mock
+    private SeatsOutboxJpaRepository seatsOutboxJpaRepository;
+
+    @Mock
+    private ScheduleSeatRepository scheduleSeatRepository;
+
+    @Mock
+    private SeatReservationRedisRepository seatReservationRedisRepository;
+
+    @Mock
+    private ReservationStatusRedisRepository reservationStatusRedisRepository;
+
+    @Mock
+    private SeatsOutboxProducer seatsOutboxProducer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private String testReservationToken;
+    private List<Long> testSeatIds;
+
+    @BeforeEach
+    void setUp() {
+        testReservationToken = "test-token-12345";
+        testSeatIds = List.of(1L, 2L, 3L);
+    }
+
+    @Test
+    @DisplayName("예약 요청 성공 시 아웃박스 저장 및 Kafka 전송")
+    void shouldSaveOutboxAndSendToKafkaWhenReservationSucceeds() {
+        // Given
+        when(seatReservationRedisRepository.attemptSeatReservation(any(), anyString())).thenReturn(true);
+        
+        SeatsOutbox mockSavedOutbox = SeatsOutbox.builder()
+                .reservationToken(testReservationToken)
+                .seatIds("[1,2,3]")
+                .status(SeatsOutbox.OutboxStatus.PENDING)
+                .build();
+
+        when(seatsOutboxJpaRepository.save(any(SeatsOutbox.class)))
+                .thenReturn(mockSavedOutbox);
+
+        // When
+        reservationService.reserveSeats(testSeatIds, testReservationToken);
+
+        // Then: Redis 좌석 예약 시도 검증
+        verify(seatReservationRedisRepository, times(1))
+                .attemptSeatReservation(testSeatIds, testReservationToken);
+
+        // Then: SeatsOutbox 저장 검증
+        ArgumentCaptor<SeatsOutbox> outboxCaptor = ArgumentCaptor.forClass(SeatsOutbox.class);
+        verify(seatsOutboxJpaRepository, times(1)).save(outboxCaptor.capture());
+
+        SeatsOutbox savedOutbox = outboxCaptor.getValue();
+        assertThat(savedOutbox.getReservationToken()).isEqualTo(testReservationToken);
+        assertThat(savedOutbox.getSeatIds()).isEqualTo("[1,2,3]"); // 실제 JSON 형태
+        assertThat(savedOutbox.getStatus()).isEqualTo(SeatsOutbox.OutboxStatus.PENDING);
+        assertThat(savedOutbox.getCreatedAt()).isNotNull();
+
+        // Then: 성공 상태 Redis 저장 검증
+        verify(reservationStatusRedisRepository, times(1))
+                .setReservationStatus(testReservationToken, "SUCCESS", "좌석 예약이 완료되었습니다.");
+
+        // Then: SeatsOutboxProducer.sendToKafkaAsync 호출 검증
+        verify(seatsOutboxProducer, times(1)).sendToKafkaAsync(mockSavedOutbox);
+    }
+
+    @Test
+    @DisplayName("Redis 좌석 예약 실패 시 실패 상태 반환")
+    void shouldSetFailedStatusWhenReservationFails() {
+        // Given: Redis 좌석 예약 실패 설정
+        when(seatReservationRedisRepository.attemptSeatReservation(any(), anyString())).thenReturn(false);
+
+        // When
+        reservationService.reserveSeats(testSeatIds, testReservationToken);
+
+        // Then: Redis 좌석 예약 시도 검증
+        verify(seatReservationRedisRepository, times(1))
+                .attemptSeatReservation(testSeatIds, testReservationToken);
+
+        // Then: 실패 상태 Redis 저장 검증
+        verify(reservationStatusRedisRepository, times(1))
+                .setReservationStatus(testReservationToken, "FAILED", "이미 예약된 좌석이 포함되어 있습니다.");
+
+        // Then: 실패 시에는 아웃박스 저장하지 않음
+        verify(seatsOutboxJpaRepository, never()).save(any());
+        verify(seatsOutboxProducer, never()).sendToKafkaAsync(any());
+    }
+
+    @Test
+    @DisplayName("여러 번 호출 시 각각 저장 및 Kafka 전송")
+    void shouldHandleMultipleReservationCalls() {
+        // Given
+        String token1 = "token-1";
+        String token2 = "token-2";
+        List<Long> seats1 = List.of(1L, 2L);
+        List<Long> seats2 = List.of(3L, 4L);
+
+        when(seatReservationRedisRepository.attemptSeatReservation(any(), anyString())).thenReturn(true);
+
+        SeatsOutbox mockOutbox1 = SeatsOutbox.builder()
+                .reservationToken(token1)
+                .seatIds("[1,2]")
+                .status(SeatsOutbox.OutboxStatus.PENDING)
+                .build();
+
+        SeatsOutbox mockOutbox2 = SeatsOutbox.builder()
+                .reservationToken(token2)
+                .seatIds("[3,4]")
+                .status(SeatsOutbox.OutboxStatus.PENDING)
+                .build();
+
+        when(seatsOutboxJpaRepository.save(any(SeatsOutbox.class)))
+                .thenReturn(mockOutbox1)
+                .thenReturn(mockOutbox2);
+
+        // When: 두 번 호출
+        reservationService.reserveSeats(seats1, token1);
+        reservationService.reserveSeats(seats2, token2);
+
+        // Then: 각각 Redis 좌석 예약 시도 검증
+        verify(seatReservationRedisRepository, times(1))
+                .attemptSeatReservation(seats1, token1);
+        verify(seatReservationRedisRepository, times(1))
+                .attemptSeatReservation(seats2, token2);
+
+        // Then: 각각 저장 및 Kafka 전송 확인
+        verify(seatsOutboxJpaRepository, times(2)).save(any(SeatsOutbox.class));
+        verify(seatsOutboxProducer, times(2)).sendToKafkaAsync(any(SeatsOutbox.class));
+
+        // Then: 성공 상태 Redis 저장 검증
+        verify(reservationStatusRedisRepository, times(2))
+                .setReservationStatus(anyString(), eq("SUCCESS"), eq("좌석 예약이 완료되었습니다."));
+
+        // 호출 순서와 내용 검증
+        ArgumentCaptor<SeatsOutbox> outboxCaptor = ArgumentCaptor.forClass(SeatsOutbox.class);
+        verify(seatsOutboxJpaRepository, times(2)).save(outboxCaptor.capture());
+        
+        List<SeatsOutbox> savedOutboxes = outboxCaptor.getAllValues();
+        assertThat(savedOutboxes).hasSize(2);
+        assertThat(savedOutboxes.get(0).getReservationToken()).isEqualTo(token1);
+        assertThat(savedOutboxes.get(1).getReservationToken()).isEqualTo(token2);
+    }
+
+    @Test
+    @DisplayName("Redis에서 예약 상태 조회")
+    void shouldReturnReservationStatus() {
+        // Given
+        ReservationStatusDto expectedStatus = ReservationStatusDto.builder()
+                .status("SUCCESS")
+                .message("좌석 예약이 완료되었습니다.")
+                .build();
+
+        when(reservationStatusRedisRepository.getReservationStatus(testReservationToken))
+                .thenReturn(expectedStatus);
+
+        // When
+        ReservationStatusDto actualStatus = reservationService.getReservationStatus(testReservationToken);
+
+        // Then
+        verify(reservationStatusRedisRepository, times(1))
+                .getReservationStatus(testReservationToken);
+        assertThat(actualStatus).isEqualTo(expectedStatus);
+        assertThat(actualStatus.getStatus()).isEqualTo("SUCCESS");
+        assertThat(actualStatus.getMessage()).isEqualTo("좌석 예약이 완료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("좌석 상태 업데이트")
+    void shouldUpdateSeatStatusSuccessfully() {
+        // Given
+        List<Long> seatIds = List.of(1L, 2L, 3L);
+
+        ScheduleSeat seat1 = mock(ScheduleSeat.class);
+        ScheduleSeat seat2 = mock(ScheduleSeat.class);
+        ScheduleSeat seat3 = mock(ScheduleSeat.class);
+        List<ScheduleSeat> mockSeats = List.of(seat1, seat2, seat3);
+
+        when(scheduleSeatRepository.findAllById(seatIds)).thenReturn(mockSeats);
+
+        // When
+        reservationService.updateSeatHold(seatIds);
+
+        // Then
+        verify(scheduleSeatRepository, times(1)).findAllById(seatIds);
+        verify(seat1, times(1)).hold();
+        verify(seat2, times(1)).hold();
+        verify(seat3, times(1)).hold();
+    }
+}

--- a/zariyo-main/src/test/java/com/zariyo/concert/integration/SeatReservationIntegrationTest.java
+++ b/zariyo-main/src/test/java/com/zariyo/concert/integration/SeatReservationIntegrationTest.java
@@ -1,0 +1,176 @@
+package com.zariyo.concert.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zariyo.config.TestContainerConfig;
+import com.zariyo.concert.api.request.ReservationRequest;
+import com.zariyo.concert.domain.entity.SeatsOutbox;
+import com.zariyo.concert.infra.SeatsOutboxJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class SeatReservationIntegrationTest extends TestContainerConfig {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private SeatsOutboxJpaRepository seatsOutboxJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private StringRedisTemplate mainRedisTemplate;
+
+    private String baseUrl;
+    private List<Long> testSeatIdList1;
+    private List<Long> testSeatIdList2;
+    private List<Long> testSeatIdList3;
+    private HttpHeaders headers;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port;
+        testSeatIdList1 = List.of(1L, 2L, 3L);
+        testSeatIdList2 = List.of(4L, 5L, 6L);
+        testSeatIdList3 = List.of(7L, 8L, 9L);
+
+        String queueToken = "test-queue-token-" + System.currentTimeMillis();
+        mainRedisTemplate.opsForValue().set("main:" + queueToken, String.valueOf(System.currentTimeMillis()));
+
+        headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("X-QUEUE-TOKEN", queueToken);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("실제 API 호출로 좌석 예약 전체 플로우 테스트")
+    void testSeatReservationApiFlow() throws Exception {
+        // Given
+        String url = baseUrl + "/api/reservations";
+        ReservationRequest request = ReservationRequest.builder()
+                .seatIds(testSeatIdList1)
+                .build();
+        HttpEntity<ReservationRequest> entity = new HttpEntity<>(request, headers);
+
+        // When
+        ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+
+        // Then
+        String reservationToken = objectMapper.readTree(response.getBody()).get("token").asText();
+        assertThat(reservationToken).isNotNull().isNotEmpty();
+
+        // Outbox 확인
+        Thread.sleep(5000);
+        SeatsOutbox outbox = seatsOutboxJpaRepository.findByReservationToken(reservationToken).orElse(null);
+        assertThat(outbox).isNotNull();
+        assertThat(outbox.getStatus()).isEqualTo(SeatsOutbox.OutboxStatus.SENT);
+    }
+
+    @Test
+    @DisplayName("좌석 예약 상태 조회 API 테스트")
+    void testReservationStatusApi() throws Exception {
+        // Given
+        String reservationUrl = baseUrl + "/api/reservations";
+        ReservationRequest request = ReservationRequest.builder()
+                .seatIds(testSeatIdList2)
+                .build();
+        
+        HttpEntity<ReservationRequest> entity = new HttpEntity<>(request, headers);
+        ResponseEntity<String> reservationResponse = restTemplate.postForEntity(reservationUrl, entity, String.class);
+        
+        JsonNode jsonNode = objectMapper.readTree(reservationResponse.getBody());
+        String redirectUrl = jsonNode.get("redirectUrl").asText();
+        
+        // When
+        String statusUrl = baseUrl + redirectUrl;
+        HttpEntity<Void> statusEntity = new HttpEntity<>(headers);
+        ResponseEntity<String> statusResponse = restTemplate.exchange(
+                statusUrl, HttpMethod.GET, statusEntity, String.class);
+
+        // Then
+        assertThat(statusResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String responseBody = statusResponse.getBody();
+        assertThat(responseBody).satisfiesAnyOf(
+                body -> assertThat(body).contains("SUCCESS"),
+                body -> assertThat(body).contains("FAILED")
+        );
+    }
+
+    @Test
+    @DisplayName("동시 좌석 예약 요청 시 중복 방지 테스트")
+    void testConcurrentSeatReservation() throws Exception {
+        // Given
+        String url = baseUrl + "/api/reservations";
+        String firstToken = "first-token-" + System.currentTimeMillis();
+        String secondToken = "second-token-" + System.currentTimeMillis();
+        
+        mainRedisTemplate.opsForValue().set("main:" + firstToken, String.valueOf(System.currentTimeMillis()));
+        mainRedisTemplate.opsForValue().set("main:" + secondToken, String.valueOf(System.currentTimeMillis()));
+        
+        ReservationRequest request = ReservationRequest.builder()
+                .seatIds(testSeatIdList3)
+                .build();
+
+        HttpHeaders headers1 = new HttpHeaders();
+        headers1.setContentType(MediaType.APPLICATION_JSON);
+        headers1.set("X-QUEUE-TOKEN", firstToken);
+        HttpEntity<ReservationRequest> entity1 = new HttpEntity<>(request, headers1);
+
+        HttpHeaders headers2 = new HttpHeaders();
+        headers2.setContentType(MediaType.APPLICATION_JSON);
+        headers2.set("X-QUEUE-TOKEN", secondToken);
+        HttpEntity<ReservationRequest> entity2 = new HttpEntity<>(request, headers2);
+
+        // When
+        ResponseEntity<String> response1 = restTemplate.postForEntity(url, entity1, String.class);
+        ResponseEntity<String> response2 = restTemplate.postForEntity(url, entity2, String.class);
+
+        String reservationToken1 = objectMapper.readTree(response1.getBody()).get("token").asText();
+        String reservationToken2 = objectMapper.readTree(response2.getBody()).get("token").asText();
+
+        // 상태 조회
+        String statusUrl1 = baseUrl + "/api/reservations/status?token=" + reservationToken1;
+        String statusUrl2 = baseUrl + "/api/reservations/status?token=" + reservationToken2;
+        
+        ResponseEntity<String> statusResponse1 = restTemplate.exchange(
+                statusUrl1, HttpMethod.GET, new HttpEntity<>(headers1), String.class);
+        ResponseEntity<String> statusResponse2 = restTemplate.exchange(
+                statusUrl2, HttpMethod.GET, new HttpEntity<>(headers2), String.class);
+        
+        // Then
+        boolean firstSuccess = "SUCCESS".equals(objectMapper.readTree(statusResponse1.getBody()).get("status").asText());
+        boolean secondSuccess = "SUCCESS".equals(objectMapper.readTree(statusResponse2.getBody()).get("status").asText());
+        
+        // 둘 중 하나만 성공
+        assertThat(firstSuccess ^ secondSuccess).isTrue();
+
+        // 성공한 요청에 대해서만 Outbox 확인
+        String successReservationToken = firstSuccess ? reservationToken1 : reservationToken2;
+        
+        Thread.sleep(2000);
+        SeatsOutbox outbox = seatsOutboxJpaRepository.findByReservationToken(successReservationToken).orElse(null);
+        assertThat(outbox).isNotNull();
+        assertThat(outbox.getStatus()).isEqualTo(SeatsOutbox.OutboxStatus.SENT);
+    }
+}

--- a/zariyo-main/src/test/java/com/zariyo/config/TestContainerConfig.java
+++ b/zariyo-main/src/test/java/com/zariyo/config/TestContainerConfig.java
@@ -5,18 +5,21 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
 
 @SpringBootTest
 @ActiveProfiles("test")
 public abstract class TestContainerConfig {
-    
+
     protected static MySQLContainer<?> mysql;
     protected static GenericContainer<?> mainRedis;
-    
+    protected static KafkaContainer kafka;
+
     static {
         mysql = new MySQLContainer<>("mysql:8.4.5")
                 .withDatabaseName("testdb")
@@ -27,8 +30,17 @@ public abstract class TestContainerConfig {
                 .withExposedPorts(6379)
                 .withCommand("redis-server");
 
+        kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+                .withEmbeddedZookeeper()
+                .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
+                .withEnv("KAFKA_NUM_PARTITIONS", "3")
+                .withEnv("KAFKA_DEFAULT_REPLICATION_FACTOR", "1")
+                .withStartupTimeout(Duration.ofSeconds(60));
+
+
         mysql.start();
         mainRedis.start();
+        kafka.start();
     }
 
     @DynamicPropertySource
@@ -42,5 +54,7 @@ public abstract class TestContainerConfig {
 
         registry.add("redis.main.host", () -> mainRedis.getHost());
         registry.add("redis.main.port", () -> mainRedis.getMappedPort(6379));
+
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
     }
 }

--- a/zariyo-main/src/test/resources/application-test.yml
+++ b/zariyo-main/src/test/resources/application-test.yml
@@ -11,3 +11,29 @@ spring:
     init:
       mode: always
       data-locations: classpath:test-data.sql
+
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      retries: 3
+      properties:
+        enable.idempotence: true
+        max.in.flight.requests.per.connection: 5
+    consumer:
+      group-id: zariyo-reservation-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      max-poll-records: 100
+      properties:
+        spring.json.trusted.packages: "com.zariyo.concert.application.consumer.event"
+    listener:
+      ack-mode: record
+      concurrency: 3
+management:
+  health:
+    kafka:
+      enabled: true


### PR DESCRIPTION
## 시스템 아키텍처 및 플로우

### 1️⃣ 좌석 예약 요청 및 즉시 응답

```mermaid
sequenceDiagram
    participant Client as 클라이언트
    participant RC as ReservationController
    participant CF as ConcertFacade
    participant RS as ReservationService
    participant SRR as SeatReservationRedisRepository
    participant RSR as ReservationStatusRedisRepository
    participant OutboxJPA as SeatsOutboxJpaRepository
    participant SOP as SeatsOutboxProducer

    Note over Client, SOP: 1️⃣ 좌석 예약 요청 및 즉시 응답 (CompletableFuture)

    Client->>RC: POST /api/reservations<br/>{seatIds: [1,2,3]}
    RC->>CF: reserveSeats(seatIds)
    
    Note over CF: UUID 토큰 생성
    CF->>CF: reservationToken = UUID.randomUUID()
    
    Note over CF: CompletableFuture.supplyAsync 시작
    CF->>RS: reserveSeats(seatIds, reservationToken)
    
    Note over RS, SRR: Redis 원자적 좌석 잠금
    RS->>SRR: attemptSeatReservation(seatIds, token)
    SRR-->>RS: true/false (예약 성공/실패)
    
    alt 예약 성공
        RS->>OutboxJPA: save(SeatsOutbox - PENDING)
        RS->>RSR: setReservationStatus(token, "SUCCESS", "완료")
        RS->>SOP: sendToKafkaAsync(outbox)
        Note over SOP: 백그라운드에서 Kafka 발행
    else 예약 실패
        RS->>RSR: setReservationStatus(token, "FAILED", "실패")
    end
    
    CF-->>RC: ReservationTokenResponse<br/>{token, redirectUrl}
    RC-->>Client: 200 OK<br/>{token, redirectUrl: "/api/reservations/status?token=..."}
    
    Note over Client: 클라이언트는 즉시 토큰과<br/>redirectUrl을 받음
```

### 2️⃣ 예약 상태 조회

```mermaid
sequenceDiagram
    participant Client as 클라이언트
    participant RC as ReservationController
    participant CF as ConcertFacade
    participant RS as ReservationService
    participant RSR as ReservationStatusRedisRepository

    Note over Client, RSR: 2️⃣ 예약 상태 조회 (redirectUrl로 요청)

    Client->>RC: GET /api/reservations/status?token=abc123
    RC->>CF: getReservationStatus(token)
    CF->>RS: getReservationStatus(token)
    
    RS->>RSR: getReservationStatus(token)
    RSR-->>RS: ReservationStatusDto<br/>{status, message}
    
    alt 상태 존재
        RS-->>CF: ReservationStatusDto
        CF-->>RC: ReservationStatusResponse<br/>{status: "SUCCESS/FAILED", message}
    else 상태 없음
        RS-->>CF: null
        CF-->>RC: ReservationStatusResponse<br/>{status: "PENDING", message: "처리중"}
    end
    
    RC-->>Client: 200 OK + 예약 상태
    
    Note over Client: SUCCESS: 예약 완료<br/>FAILED: 예약 실패<br/>PENDING: 처리 중
```

### 3️⃣ 백그라운드 비동기 처리 (Kafka + Outbox)

```mermaid
sequenceDiagram
    participant SOP as SeatsOutboxProducer
    participant Kafka as Kafka
    participant RCons as ReservationConsumer
    participant RS as ReservationService
    participant SSR as ScheduleSeatRepository
    participant OutboxJPA as SeatsOutboxJpaRepository

    Note over SOP, OutboxJPA: 3️⃣ 백그라운드 비동기 처리 (사용자 응답과 독립적)

    Note over SOP: 1단계에서 시작된<br/>sendToKafkaAsync 실행
    
    SOP->>SOP: createKafkaEvent(outbox)
    SOP->>Kafka: send("reservation-requests", event)
    
    alt Kafka 전송 성공
        Kafka-->>SOP: 전송 완료 콜백
        SOP->>OutboxJPA: outbox.markAsSent()<br/>save(outbox)
        
        Note over Kafka, RCons: 비동기 이벤트 소비
        Kafka->>RCons: ReservationRequestEvent 수신
        RCons->>RS: updateSeatHold(seatIds)
        RS->>SSR: findAllById(seatIds)
        SSR-->>RS: List<ScheduleSeat>
        RS->>SSR: scheduleSeat.hold() 각 좌석에 대해
        
    else Kafka 전송 실패
        Kafka-->>SOP: 전송 실패 콜백
        SOP->>SSR: 직접 DB 업데이트<br/>scheduleSeat.hold()
        SOP->>OutboxJPA: outbox.markAsFailed()<br/>save(outbox)
    end
    
    Note over SOP, OutboxJPA: Outbox 패턴으로<br/>데이터 일관성 보장
```